### PR TITLE
kwin/input/emitter: fix build failure on KWin master

### DIFF
--- a/src/kwin/input/emitter.cpp
+++ b/src/kwin/input/emitter.cpp
@@ -18,14 +18,6 @@
 
 #include "emitter.h"
 #include "utils.h"
-#include "cursor.h"
-
-#include "core/output.h"
-#include "keyboard_input.h"
-#include "pointer_input.h"
-#include "workspace.h"
-
-#include <linux/input-event-codes.h>
 
 #include <libinputactions/input/backend.h>
 
@@ -34,8 +26,6 @@ KWinInputEmitter::KWinInputEmitter()
 {
     auto input = KWin::input();
     input->addInputDevice(m_device.get());
-    m_pointer = input->pointer();
-    m_keyboard = input->keyboard();
 }
 
 KWinInputEmitter::~KWinInputEmitter()
@@ -48,23 +38,23 @@ KWinInputEmitter::~KWinInputEmitter()
 void KWinInputEmitter::keyboardKey(const uint32_t &key, const bool &state)
 {
     libinputactions::InputBackend::instance()->setIgnoreEvents(true);
-    m_keyboard->processKey(key, state ? KeyboardKeyStatePressed : KeyboardKeyStateReleased, timestamp(), m_device.get());
+    Q_EMIT m_device->keyChanged(key, state ? KeyboardKeyStatePressed : KeyboardKeyStateReleased, timestamp(), m_device.get());
     libinputactions::InputBackend::instance()->setIgnoreEvents(false);
 }
 
 void KWinInputEmitter::mouseButton(const uint32_t &button, const bool &state)
 {
     libinputactions::InputBackend::instance()->setIgnoreEvents(true);
-    m_pointer->processButton(button, state ? PointerButtonStatePressed : PointerButtonStateReleased, timestamp(), m_device.get());
-    m_pointer->processFrame(m_device.get());
+    Q_EMIT m_device->pointerButtonChanged(button, state ? PointerButtonStatePressed : PointerButtonStateReleased, timestamp(), m_device.get());
+    Q_EMIT m_device->pointerFrame(m_device.get());
     libinputactions::InputBackend::instance()->setIgnoreEvents(false);
 }
 
 void KWinInputEmitter::mouseMoveRelative(const QPointF &pos)
 {
     libinputactions::InputBackend::instance()->setIgnoreEvents(true);
-    m_pointer->processMotion(pos, pos, timestamp(), m_device.get());
-    m_pointer->processFrame(m_device.get());
+    Q_EMIT m_device->pointerMotion(pos, pos, timestamp(), m_device.get());
+    Q_EMIT m_device->pointerFrame(m_device.get());
     libinputactions::InputBackend::instance()->setIgnoreEvents(false);
 }
 

--- a/src/kwin/input/emitter.h
+++ b/src/kwin/input/emitter.h
@@ -79,8 +79,5 @@ public:
     InputDevice *device() const;
 
 private:
-    KWin::PointerInputRedirection *m_pointer;
-    KWin::KeyboardInputRedirection *m_keyboard;
-
     std::unique_ptr<InputDevice> m_device;
 };

--- a/src/kwin/input/keyboard.cpp
+++ b/src/kwin/input/keyboard.cpp
@@ -18,11 +18,11 @@
 
 #include "keyboard.h"
 
-#include "keyboard_input.h"
 #include "workspace.h"
 
 #include <libinputactions/input/backend.h>
 #include <libinputactions/input/emitter.h>
+#include <libinputactions/input/keyboard.h>
 
 void KWinKeyboard::clearModifiers()
 {
@@ -34,7 +34,7 @@ void KWinKeyboard::clearModifiers()
     }
 
     auto emitter = libinputactions::InputEmitter::instance();
-    const auto modifiers = KWin::input()->keyboard()->modifiers();
+    const auto modifiers = libinputactions::Keyboard::instance()->modifiers(); // This is not the real state, but it's fine in this case.
     for (const auto &[key, modifier] : libinputactions::s_modifiers) {
         if (modifiers & modifier) {
             emitter->keyboardKey(key, false);

--- a/src/libinputactions/input/keyboard.h
+++ b/src/libinputactions/input/keyboard.h
@@ -49,7 +49,9 @@ public:
     void handleEvent(const KeyboardKeyEvent *event);
 
     /**
-     * @return Currently pressed keyboard modifiers.
+     * @return Currently pressed keyboard modifiers
+     * @remark Key events that have been ignored by the input backend will not be used to update the modifier state. For example, clearing modifiers will not
+     * update the modifier state to none. This allows gestures with keyboard modifier conditions to be used again.
      */
     const Qt::KeyboardModifiers &modifiers() const;
     virtual void clearModifiers();


### PR DESCRIPTION
This also removes the use of methods marked with ``@internal``.