### PR TITLE
libinputactions/trigger: ensure delta within threshold in Trigger::canEnd

### DIFF
--- a/src/libinputactions/triggers/trigger.h
+++ b/src/libinputactions/triggers/trigger.h
@@ -185,7 +185,7 @@ private:
     std::optional<Qt::MouseButtons> m_mouseButtons;
 
     std::optional<Range<qreal>> m_threshold;
-    bool m_thresholdReached = false;
+    bool m_withinThreshold = false;
     qreal m_absoluteAccumulatedDelta = 0;
 
     friend class TestTrigger;


### PR DESCRIPTION
Fixes an issue where gestures would end even if the total delta didn't fit within the specified threshold range.