### PR TITLE
libinputactions: make wheel gestures continuous only when an update action is present

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ set(libinputactions_SRCS
     libinputactions/triggers/press.cpp
     libinputactions/triggers/stroke.cpp
     libinputactions/triggers/trigger.cpp
+    libinputactions/triggers/wheel.cpp
     libinputactions/variables/manager.cpp
     libinputactions/variables/operations.cpp
     libinputactions/variables/variable.cpp

--- a/src/libinputactions/handlers/mouse.cpp
+++ b/src/libinputactions/handlers/mouse.cpp
@@ -22,6 +22,7 @@
 #include <libinputactions/input/keyboard.h>
 #include <libinputactions/input/pointer.h>
 #include <libinputactions/triggers/press.h>
+#include <libinputactions/triggers/wheel.h>
 
 Q_LOGGING_CATEGORY(LIBINPUTACTIONS_HANDLER_MOUSE, "libinputactions.handler.mouse", QtWarningMsg)
 
@@ -206,8 +207,15 @@ bool MouseTriggerHandler::handleWheelEvent(const MotionEvent *event)
     DirectionalMotionTriggerUpdateEvent updateEvent;
     updateEvent.setDelta(delta.x() != 0 ? delta.x() : delta.y());
     updateEvent.setDirection(static_cast<TriggerDirection>(direction));
+
     const auto hasTriggers = updateTriggers(TriggerType::Wheel, &updateEvent);
-    if (!m_buttons && !Keyboard::instance()->modifiers()) {
+    bool continuous = false;
+    for (const auto &trigger : activeTriggers(TriggerType::Wheel)) {
+        if (static_cast<WheelTrigger *>(trigger)->continuous()) {
+            continuous = true;
+        }
+    }
+    if (!continuous || (!m_buttons && !Keyboard::instance()->modifiers())) {
         qCDebug(LIBINPUTACTIONS_HANDLER_MOUSE, "Wheel trigger will end immediately");
         endTriggers(TriggerType::Wheel);
     }

--- a/src/libinputactions/handlers/mouse.h
+++ b/src/libinputactions/handlers/mouse.h
@@ -33,10 +33,6 @@ namespace libinputactions
  * triggers instant as well.
  * @see setMotionTimeout
  * @see PressTrigger::setInstant
- *
- * Wheel triggers have a different lifecycle than other triggers, as they are activated, updated and ended on
- * every single event. They are never cancelled and do not support speed or thresholds, although there are no checks
- * against that.
  */
 class MouseTriggerHandler : public MotionTriggerHandler
 {

--- a/src/libinputactions/triggers/trigger.cpp
+++ b/src/libinputactions/triggers/trigger.cpp
@@ -29,12 +29,7 @@ namespace libinputactions
 
 void Trigger::addAction(std::unique_ptr<TriggerAction> action)
 {
-    if (dynamic_cast<InputTriggerAction *>(action.get())) {
-        if (!m_clearModifiers) {
-            m_clearModifiers = true;
-        }
-    }
-
+    actionAdded(action.get());
     m_actions.push_back(std::move(action));
 }
 
@@ -145,6 +140,15 @@ bool Trigger::overridesOtherTriggersOnUpdate()
     return std::any_of(m_actions.begin(), m_actions.end(), [](const auto &action) {
         return action->executed() || (action->on() == On::Update && action->canExecute());
     });
+}
+
+void Trigger::actionAdded(TriggerAction *action)
+{
+    if (dynamic_cast<InputTriggerAction *>(action)) {
+        if (!m_clearModifiers) {
+            m_clearModifiers = true;
+        }
+    }
 }
 
 const std::vector<TriggerAction *> Trigger::actions()

--- a/src/libinputactions/triggers/trigger.h
+++ b/src/libinputactions/triggers/trigger.h
@@ -156,6 +156,11 @@ public:
     void setType(const TriggerType &type);
 
 protected:
+    /**
+     * Called when an action is added. May be used to change default behavior.
+     */
+    virtual void actionAdded(TriggerAction *action);
+
     const std::vector<TriggerAction *> actions();
 
     virtual void updateActions(const TriggerUpdateEvent *event);

--- a/src/libinputactions/triggers/wheel.cpp
+++ b/src/libinputactions/triggers/wheel.cpp
@@ -1,0 +1,42 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "wheel.h"
+
+namespace libinputactions
+{
+
+WheelTrigger::WheelTrigger()
+{
+    setType(TriggerType::Wheel);
+}
+
+void WheelTrigger::actionAdded(TriggerAction *action)
+{
+    DirectionalMotionTrigger::actionAdded(action);
+    if (action->on() == On::Update) {
+        m_continuous = true;
+    }
+}
+
+bool WheelTrigger::continuous() const
+{
+    return m_continuous;
+}
+
+}

--- a/src/libinputactions/triggers/wheel.h
+++ b/src/libinputactions/triggers/wheel.h
@@ -1,0 +1,44 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "directionalmotion.h"
+
+namespace libinputactions
+{
+
+/**
+ * Wheel triggers are continuous when an update action is present and a mouse button or a keyboard modifier is present. Continuous triggers begin on a scroll
+ * event and end on modifier or button release. Non-continuous triggers begin and end on the same scroll event.
+ */
+class WheelTrigger : public DirectionalMotionTrigger
+{
+public:
+    WheelTrigger();
+
+    bool continuous() const;
+
+protected:
+    void actionAdded(TriggerAction *action) override;
+
+private:
+    bool m_continuous = false;
+};
+
+}

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -27,9 +27,9 @@
 #include <libinputactions/handlers/mouse.h>
 #include <libinputactions/handlers/touchpad.h>
 #include <libinputactions/input/handler.h>
-#include <libinputactions/triggers/directionalmotion.h>
 #include <libinputactions/triggers/press.h>
 #include <libinputactions/triggers/stroke.h>
+#include <libinputactions/triggers/wheel.h>
 #include <libinputactions/variables/manager.h>
 #include <libinputactions/variables/variable.h>
 #include <libinputactions/expression.cpp>
@@ -916,8 +916,7 @@ struct convert<std::unique_ptr<Trigger>>
             rotateTrigger->setDirection(static_cast<TriggerDirection>(node["direction"].as<RotateDirection>()));
             trigger.reset(rotateTrigger);
         } else if (type == "wheel") {
-            auto wheelTrigger = new DirectionalMotionTrigger;
-            wheelTrigger->setType(TriggerType::Wheel);
+            auto wheelTrigger = new WheelTrigger;
             wheelTrigger->setDirection(static_cast<TriggerDirection>(node["direction"].as<SwipeDirection>()));
             trigger.reset(wheelTrigger);
         } else {


### PR DESCRIPTION
Wheel gestures will no longer suddenly work in a completely different way when a modifier or button is present. Now the gesture must have an update action in order for that to happen.