### PR TITLE
libinputactions/touchpad: improve scroll handling

### DIFF
--- a/src/kwin/input/backend.cpp
+++ b/src/kwin/input/backend.cpp
@@ -258,6 +258,7 @@ bool KWinInputBackend::wheelEvent(KWin::WheelEvent *event)
         return false;
     }
 
+    // A scroll delta of (0,0) marks the end of a scroll gesture
     auto delta = orientation == Qt::Orientation::Horizontal
         ? QPointF(eventDelta, 0)
         : QPointF(0, eventDelta);
@@ -271,8 +272,11 @@ bool KWinInputBackend::wheelEvent(KWin::WheelEvent *event)
     }
 
     if (m_isRecordingStroke) {
-        m_strokePoints.push_back(delta);
-        m_strokeRecordingTimeoutTimer.start(s_strokeRecordingTimeout);
+        if (delta.isNull()) {
+            finishStrokeRecording();
+        } else {
+            m_strokePoints.push_back(delta);
+        }
         return true;
     }
 

--- a/src/libinputactions/handlers/touchpad.h
+++ b/src/libinputactions/handlers/touchpad.h
@@ -31,28 +31,20 @@ namespace libinputactions
 class TouchpadTriggerHandler : public MultiTouchMotionTriggerHandler
 {
 public:
-    TouchpadTriggerHandler();
+    TouchpadTriggerHandler() = default;
 
     bool handleEvent(const InputEvent *event) override;
-
-    /**
-     * The time of inactivity in milliseconds after which 2-finger motion triggers will end.
-     */
-    void setScrollTimeout(const uint32_t &timeout);
 
 private:
     bool handleEvent(const TouchpadGestureLifecyclePhaseEvent *event);
     bool handleEvent(const TouchpadPinchEvent *event);
     /**
-     * The event is treated as a 2-finger swipe. Will not work if edge scrolling is enabled. The handler is not aware
-     * when the finger count changes, therefore it relies on a timeout to end triggers.
-     * @see setScrollTimeout
+     * The event is treated as two-finger motion. Will not work if edge scrolling is enabled.
      */
     bool handleScrollEvent(const MotionEvent *event);
     bool handleSwipeEvent(const MotionEvent *event);
 
-    uint32_t m_scrollTimeout = 100;
-    QTimer m_scrollTimeoutTimer;
+    bool m_scrollInProgress{};
 };
 
 }

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -1143,9 +1143,6 @@ struct convert<std::unique_ptr<TouchpadTriggerHandler>>
         if (const auto &deltaMultiplierNode = node["delta_multiplier"]) {
             touchpadTriggerHandler->setSwipeDeltaMultiplier(deltaMultiplierNode.as<qreal>());
         }
-        if (const auto &scrollTimeoutNode = node["scroll_timeout"]) {
-            touchpadTriggerHandler->setScrollTimeout(scrollTimeoutNode.as<uint32_t>());
-        }
         return true;
     }
 };


### PR DESCRIPTION
So it turns out that it is possible to detect the end of scroll gestures by checking for a delta of (0,0), which removes the need to rely on timeouts.

Events with a delta of (0,0) will never be blocked anymore, as this would mess up kinetic scrolling.

Fixes #115