### PR TITLE
kwin: fix plasma_overview_active variable

### DIFF
--- a/src/kwin/Effect.cpp
+++ b/src/kwin/Effect.cpp
@@ -55,6 +55,8 @@ Effect::Effect()
         // does fortunately have them.
         if (const auto *effect = dynamic_cast<KWin::Effect *>(KWin::effects->activeFullScreenEffect())) {
             value = effect->property("overviewGestureInProgress").isValid();
+        } else {
+            value = false;
         }
     });
     variableManager->registerRemoteVariable<QString>("screen_name", [](auto &value) {


### PR DESCRIPTION
If value is not set, the variable becomes empty and a ``== false`` condition is not possible.