### PR TITLE
libinputactions: add last_trigger_id variable

### DIFF
--- a/src/libinputactions/handlers/MotionTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MotionTriggerHandler.cpp
@@ -180,7 +180,7 @@ void MotionTriggerHandler::triggerActivating(const Trigger *trigger)
     TriggerHandler::triggerActivating(trigger);
     if (const auto motionTrigger = dynamic_cast<const MotionTrigger *>(trigger)) {
         if (!m_isDeterminingSpeed && motionTrigger->hasSpeed()) {
-            qCDebug(INPUTACTIONS_HANDLER_MOTION).noquote() << QString("Trigger has speed (name: %1)").arg(trigger->name());
+            qCDebug(INPUTACTIONS_HANDLER_MOTION).noquote() << QString("Trigger has speed (id: %1)").arg(trigger->id());
             m_isDeterminingSpeed = true;
         }
     }

--- a/src/libinputactions/handlers/MouseTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MouseTriggerHandler.cpp
@@ -271,7 +271,7 @@ bool MouseTriggerHandler::shouldBlockMouseButton(const Qt::MouseButton &button)
     for (const auto &trigger : triggers(TriggerType::All, event.get())) {
         const auto buttons = trigger->mouseButtons();
         if (buttons && (*buttons & button)) {
-            qCDebug(INPUTACTIONS_HANDLER_MOUSE).noquote().nospace() << "Mouse button blocked (button: " << button << ", trigger: " << trigger->name() << ")";
+            qCDebug(INPUTACTIONS_HANDLER_MOUSE).noquote().nospace() << "Mouse button blocked (button: " << button << ", trigger: " << trigger->id() << ")";
             return true;
         }
     }

--- a/src/libinputactions/handlers/TriggerHandler.cpp
+++ b/src/libinputactions/handlers/TriggerHandler.cpp
@@ -20,6 +20,7 @@
 
 #include <libinputactions/input/Keyboard.h>
 #include <libinputactions/interfaces/InputEmitter.h>
+#include <libinputactions/variables/VariableManager.h>
 
 Q_LOGGING_CATEGORY(INPUTACTIONS_HANDLER_TRIGGER, "inputactions.handler.trigger", QtWarningMsg)
 
@@ -98,7 +99,7 @@ bool TriggerHandler::activateTriggers(const TriggerTypes &types, const TriggerAc
     for (auto &trigger : triggers(types, event)) {
         triggerActivating(trigger);
         m_activeTriggers.push_back(trigger);
-        qCDebug(INPUTACTIONS_HANDLER_TRIGGER).noquote() << QString("Trigger activated (name: %1)").arg(trigger->name());
+        qCDebug(INPUTACTIONS_HANDLER_TRIGGER).noquote() << QString("Trigger activated (id: %1)").arg(trigger->id());
     }
     m_timedTriggerUpdateTimer.start();
 
@@ -139,7 +140,9 @@ bool TriggerHandler::updateTriggers(const std::map<TriggerType, const TriggerUpd
         }
 
         hasTriggers = true;
-        trigger->update(event);
+        if (trigger->update(event)) {
+            VariableManager::instance()->getVariable(BuiltinVariables::LastTriggerId)->set(trigger->id());
+        }
 
         if (!m_conflictsResolved && m_activeTriggers.size() > 1) {
             qCDebug(INPUTACTIONS_TRIGGER, "Cancelling conflicting triggers");
@@ -231,7 +234,7 @@ bool TriggerHandler::cancelTriggers(const TriggerTypes &types)
 
 void TriggerHandler::cancelTriggers(Trigger *except)
 {
-    qCDebug(INPUTACTIONS_HANDLER_TRIGGER).noquote().nospace() << "Cancelling triggers (except: " << except->name() << ")";
+    qCDebug(INPUTACTIONS_HANDLER_TRIGGER).noquote().nospace() << "Cancelling triggers (except: " << except->id() << ")";
     for (auto it = m_activeTriggers.begin(); it != m_activeTriggers.end();) {
         auto gesture = *it;
         if (gesture != except) {

--- a/src/libinputactions/triggers/Trigger.cpp
+++ b/src/libinputactions/triggers/Trigger.cpp
@@ -56,25 +56,25 @@ bool Trigger::canUpdate(const TriggerUpdateEvent *) const
     return true;
 }
 
-void Trigger::update(const TriggerUpdateEvent *event)
+bool Trigger::update(const TriggerUpdateEvent *event)
 {
     m_absoluteAccumulatedDelta += std::abs(event->delta());
     m_withinThreshold = !m_threshold || m_threshold->contains(m_absoluteAccumulatedDelta);
     if (!m_withinThreshold) {
         qCDebug(INPUTACTIONS_TRIGGER).noquote()
-            << QString("Threshold not reached (name: %1, current: %2, min: %3, max: %4")
-                .arg(m_name, QString::number(m_absoluteAccumulatedDelta), QString::number(m_threshold->min().value_or(-1)), QString::number(m_threshold->max().value_or(-1)));
-        return;
+            << QString("Threshold not reached (id: %1, current: %2, min: %3, max: %4")
+                .arg(m_id, QString::number(m_absoluteAccumulatedDelta), QString::number(m_threshold->min().value_or(-1)), QString::number(m_threshold->max().value_or(-1)));
+        return false;
     }
 
-    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger updated (name: %1, delta: %2)").arg(m_name, QString::number(event->delta()));
+    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger updated (id: %1, delta: %2)").arg(m_id, QString::number(event->delta()));
 
     if (!m_started) {
-        qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger started (name: %1)").arg(m_name);
+        qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger started (id: %1)").arg(m_id);
         m_started = true;
 
         if (m_clearModifiers && *m_clearModifiers) {
-            qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Clearing keyboard modifiers (trigger: %1)").arg(m_name);
+            qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Clearing keyboard modifiers (trigger: %1)").arg(m_id);
             InputEmitter::instance()->keyboardClearModifiers();
         }
 
@@ -84,6 +84,7 @@ void Trigger::update(const TriggerUpdateEvent *event)
     }
 
     updateActions(event);
+    return true;
 }
 
 bool Trigger::canEnd() const
@@ -98,7 +99,7 @@ void Trigger::end()
         return;
     }
 
-    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger ended (name: %1)").arg(m_name);
+    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger ended (id: %1)").arg(m_id);
     for (const auto &action : m_actions) {
         action->triggerEnded();
     }
@@ -112,7 +113,7 @@ void Trigger::cancel()
         return;
     }
 
-    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger cancelled (name: %1)").arg(m_name);
+    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger cancelled (id: %1)").arg(m_id);
     for (const auto &action : m_actions) {
         action->triggerCancelled();
     }
@@ -186,14 +187,14 @@ void Trigger::setMouseButtons(const std::optional<Qt::MouseButtons> &buttons)
     m_mouseButtons = buttons;
 }
 
-const QString &Trigger::name() const
+const QString &Trigger::id() const
 {
-    return m_name;
+    return m_id;
 }
 
-void Trigger::setName(const QString &name)
+void Trigger::setId(const QString &value)
 {
-    m_name = name;
+    m_id = value;
 }
 
 const TriggerType &Trigger::type() const

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -84,9 +84,10 @@ public:
      */
     virtual bool canUpdate(const TriggerUpdateEvent *event) const;
     /**
+     * @returns Whether the trigger has been updated. False if threshold not reached.
      * @internal
      */
-    TEST_VIRTUAL void update(const TriggerUpdateEvent *event);
+    TEST_VIRTUAL bool update(const TriggerUpdateEvent *event);
 
     /**
      * Called by the trigger handler before ending a trigger. If true is returned, that trigger will be cancelled
@@ -143,11 +144,11 @@ public:
      */
     void setMouseButtons(const std::optional<Qt::MouseButtons> &buttons);
 
-    const QString &name() const;
+    const QString &id() const;
     /**
-     * @param name Shown in debug logs.
+     * @param name Must be unique.
      */
-    void setName(const QString &name);
+    void setId(const QString &value);
 
     const TriggerType &type() const;
     /**
@@ -168,7 +169,7 @@ protected:
 private:
     void reset();
 
-    QString m_name = "Unnamed gesture";
+    QString m_id;
     TriggerType m_type{0};
     std::vector<std::unique_ptr<TriggerAction>> m_actions;
     bool m_started = false;

--- a/src/libinputactions/variables/VariableManager.cpp
+++ b/src/libinputactions/variables/VariableManager.cpp
@@ -46,6 +46,7 @@ VariableManager::VariableManager()
     registerRemoteVariable<Qt::KeyboardModifiers>(BuiltinVariables::KeyboardModifiers.name(), [](auto &value) {
         value = Keyboard::instance()->modifiers();
     });
+    registerLocalVariable(BuiltinVariables::LastTriggerId);
     registerRemoteVariable<QPointF>("pointer_position_screen_percentage", [](auto &value) {
         value = PointerPositionGetter::instance()->screenPointerPosition();
     });

--- a/src/libinputactions/variables/VariableManager.h
+++ b/src/libinputactions/variables/VariableManager.h
@@ -66,6 +66,7 @@ public:
     inline static const VariableInfo<QString> DeviceName{QStringLiteral("device_name")};
     inline static const VariableInfo<qreal> Fingers{QStringLiteral("fingers")};
     inline static const VariableInfo<Qt::KeyboardModifiers> KeyboardModifiers{QStringLiteral("keyboard_modifiers")};
+    inline static const VariableInfo<QString> LastTriggerId{QStringLiteral("last_trigger_id")};
     inline static const VariableInfo<QPointF> ThumbPositionPercentage{QStringLiteral("thumb_position_percentage")};
     inline static const VariableInfo<bool> ThumbPresent{QStringLiteral("thumb_present")};
 };

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -929,8 +929,8 @@ struct convert<std::unique_ptr<Trigger>>
 
         auto conditionGroup = std::make_shared<ConditionGroup>();
 
-        if (const auto &nameNode = node["name"]) {
-            trigger->setName(nameNode.as<QString>());
+        if (const auto &idNode = node["id"]) {
+            trigger->setId(idNode.as<QString>());
         }
         if (const auto &fingersNode = node["fingers"]) {
             auto range = fingersNode.as<Range<qreal>>();


### PR DESCRIPTION
This makes gesture chaining possible. Example:
```yaml
- type: press
  id: touchpad_press_3

  conditions:
    - $fingers == 3

  # no actions on purpose

# Hold 3 then swipe right
- type: swipe
  direction: right

  conditions:
    - $last_trigger_id == touchpad_press_3

  actions:
    # ...
```