### PR TITLE
libinputactions: allow mouse gestures with specific press order

### DIFF
--- a/src/libinputactions/handlers/MouseTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MouseTriggerHandler.cpp
@@ -274,8 +274,8 @@ bool MouseTriggerHandler::shouldBlockMouseButton(const Qt::MouseButton &button)
     event->mouseButtons = {};
     for (const auto &trigger : triggers(TriggerType::All, event.get())) {
         const auto buttons = trigger->mouseButtons();
-        if ((trigger->mouseButtonOrderMatters() && std::ranges::equal(m_buttons, buttons | std::views::take(m_buttons.size())))
-            || (!trigger->mouseButtonOrderMatters() && std::ranges::contains(buttons, button))) {
+        if ((trigger->mouseButtonsExactOrder() && std::ranges::equal(m_buttons, buttons | std::views::take(m_buttons.size())))
+            || (!trigger->mouseButtonsExactOrder() && std::ranges::contains(buttons, button))) {
             qCDebug(INPUTACTIONS_HANDLER_MOUSE).noquote().nospace() << "Mouse button blocked (button: " << button << ", trigger: " << trigger->id() << ")";
             return true;
         }

--- a/src/libinputactions/handlers/MouseTriggerHandler.h
+++ b/src/libinputactions/handlers/MouseTriggerHandler.h
@@ -106,7 +106,7 @@ private:
     bool m_hadTriggerSincePress = false;
 
     QList<quint32> m_blockedMouseButtons;
-    Qt::MouseButtons m_buttons{};
+    std::vector<Qt::MouseButton> m_buttons;
     bool m_unblockButtonsOnTimeout = true;
 };
 

--- a/src/libinputactions/triggers/Trigger.cpp
+++ b/src/libinputactions/triggers/Trigger.cpp
@@ -45,8 +45,14 @@ void Trigger::setEndCondition(const std::shared_ptr<const Condition> &condition)
 
 bool Trigger::canActivate(const TriggerActivationEvent *event) const
 {
-    if (m_mouseButtons && event->mouseButtons && *m_mouseButtons != event->mouseButtons) {
-        return false;
+    if (!m_mouseButtons.empty() && !event->mouseButtons.empty()) {
+        if (m_mouseButtons.size() != event->mouseButtons.size()
+            || (m_mouseButtonOrderMatters && !std::ranges::equal(m_mouseButtons, event->mouseButtons))
+            || (!m_mouseButtonOrderMatters && !std::ranges::all_of(m_mouseButtons, [event](auto &button) {
+                return std::ranges::contains(event->mouseButtons, button);
+        }))) {
+            return false;
+        }
     }
 
     return !m_activationCondition || m_activationCondition.value()->satisfied();
@@ -188,14 +194,24 @@ void Trigger::setSetLastTrigger(const bool &value)
     m_setLastTrigger = value;
 }
 
-const std::optional<Qt::MouseButtons> &Trigger::mouseButtons() const
+const std::vector<Qt::MouseButton> &Trigger::mouseButtons() const
 {
     return m_mouseButtons;
 }
 
-void Trigger::setMouseButtons(const std::optional<Qt::MouseButtons> &buttons)
+void Trigger::setMouseButtons(const std::vector<Qt::MouseButton> &buttons)
 {
     m_mouseButtons = buttons;
+}
+
+const bool &Trigger::mouseButtonOrderMatters() const
+{
+    return m_mouseButtonOrderMatters;
+}
+
+void Trigger::setMouseButtonOrderMatters(const bool &value)
+{
+    m_mouseButtonOrderMatters = value;
 }
 
 const QString &Trigger::id() const

--- a/src/libinputactions/triggers/Trigger.cpp
+++ b/src/libinputactions/triggers/Trigger.cpp
@@ -47,8 +47,8 @@ bool Trigger::canActivate(const TriggerActivationEvent *event) const
 {
     if (!m_mouseButtons.empty() && event->mouseButtons.has_value()) {
         if (m_mouseButtons.size() != event->mouseButtons->size()
-            || (m_mouseButtonOrderMatters && !std::ranges::equal(m_mouseButtons, event->mouseButtons.value()))
-            || (!m_mouseButtonOrderMatters && !std::ranges::all_of(m_mouseButtons, [event](auto &button) {
+            || (m_mouseButtonsExactOrder && !std::ranges::equal(m_mouseButtons, event->mouseButtons.value()))
+            || (!m_mouseButtonsExactOrder && !std::ranges::all_of(m_mouseButtons, [event](auto &button) {
                 return std::ranges::contains(event->mouseButtons.value(), button);
         }))) {
             return false;
@@ -204,14 +204,14 @@ void Trigger::setMouseButtons(const std::vector<Qt::MouseButton> &buttons)
     m_mouseButtons = buttons;
 }
 
-const bool &Trigger::mouseButtonOrderMatters() const
+const bool &Trigger::mouseButtonsExactOrder() const
 {
-    return m_mouseButtonOrderMatters;
+    return m_mouseButtonsExactOrder;
 }
 
-void Trigger::setMouseButtonOrderMatters(const bool &value)
+void Trigger::setMouseButtonsExactOrder(const bool &value)
 {
-    m_mouseButtonOrderMatters = value;
+    m_mouseButtonsExactOrder = value;
 }
 
 const QString &Trigger::id() const

--- a/src/libinputactions/triggers/Trigger.cpp
+++ b/src/libinputactions/triggers/Trigger.cpp
@@ -45,11 +45,11 @@ void Trigger::setEndCondition(const std::shared_ptr<const Condition> &condition)
 
 bool Trigger::canActivate(const TriggerActivationEvent *event) const
 {
-    if (!m_mouseButtons.empty() && !event->mouseButtons.empty()) {
-        if (m_mouseButtons.size() != event->mouseButtons.size()
-            || (m_mouseButtonOrderMatters && !std::ranges::equal(m_mouseButtons, event->mouseButtons))
+    if (!m_mouseButtons.empty() && event->mouseButtons.has_value()) {
+        if (m_mouseButtons.size() != event->mouseButtons->size()
+            || (m_mouseButtonOrderMatters && !std::ranges::equal(m_mouseButtons, event->mouseButtons.value()))
             || (!m_mouseButtonOrderMatters && !std::ranges::all_of(m_mouseButtons, [event](auto &button) {
-                return std::ranges::contains(event->mouseButtons, button);
+                return std::ranges::contains(event->mouseButtons.value(), button);
         }))) {
             return false;
         }

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -147,8 +147,8 @@ public:
      */
     void setMouseButtons(const std::vector<Qt::MouseButton> &buttons);
 
-    const bool &mouseButtonOrderMatters() const;
-    void setMouseButtonOrderMatters(const bool &value);
+    const bool &mouseButtonsExactOrder() const;
+    void setMouseButtonsExactOrder(const bool &value);
 
     const QString &id() const;
     /**
@@ -186,7 +186,7 @@ private:
     std::optional<std::shared_ptr<const Condition>> m_endCondition;
 
     std::vector<Qt::MouseButton> m_mouseButtons;
-    bool m_mouseButtonOrderMatters{};
+    bool m_mouseButtonsExactOrder{};
 
     std::optional<Range<qreal>> m_threshold;
     bool m_withinThreshold = false;

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -36,7 +36,7 @@ namespace libinputactions
 class TriggerActivationEvent
 {
 public:
-    std::vector<Qt::MouseButton> mouseButtons;
+    std::optional<std::vector<Qt::MouseButton>> mouseButtons;
 };
 class TriggerUpdateEvent
 {

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -36,7 +36,7 @@ namespace libinputactions
 class TriggerActivationEvent
 {
 public:
-    std::optional<Qt::MouseButtons> mouseButtons;
+    std::vector<Qt::MouseButton> mouseButtons;
 };
 class TriggerUpdateEvent
 {
@@ -140,13 +140,15 @@ public:
      */
     void setSetLastTrigger(const bool &value);
 
-    const std::optional<Qt::MouseButtons> &mouseButtons() const;
+    const std::vector<Qt::MouseButton> &mouseButtons() const;
     /**
      * Only applies to mouse triggers.
-     *
      * @param buttons Mouse buttons that must be pressed before and during the trigger.
      */
-    void setMouseButtons(const std::optional<Qt::MouseButtons> &buttons);
+    void setMouseButtons(const std::vector<Qt::MouseButton> &buttons);
+
+    const bool &mouseButtonOrderMatters() const;
+    void setMouseButtonOrderMatters(const bool &value);
 
     const QString &id() const;
     /**
@@ -183,7 +185,8 @@ private:
     std::optional<std::shared_ptr<const Condition>> m_activationCondition;
     std::optional<std::shared_ptr<const Condition>> m_endCondition;
 
-    std::optional<Qt::MouseButtons> m_mouseButtons;
+    std::vector<Qt::MouseButton> m_mouseButtons;
+    bool m_mouseButtonOrderMatters{};
 
     std::optional<Range<qreal>> m_threshold;
     bool m_withinThreshold = false;

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -964,7 +964,10 @@ struct convert<std::unique_ptr<Trigger>>
             }
         }
         if (const auto &mouseButtonsNode = node["mouse_buttons"]) {
-            trigger->setMouseButtons(mouseButtonsNode.as<Qt::MouseButtons>());
+            trigger->setMouseButtons(mouseButtonsNode.as<std::vector<Qt::MouseButton>>());
+        }
+        if (const auto &mouseButtonsNode = node["mouse_button_order_matters"]) {
+            trigger->setMouseButtonOrderMatters(mouseButtonsNode.as<bool>());
         }
         if (const auto &conditionsNode = node["conditions"]) {
             conditionGroup->add(conditionsNode.as<std::shared_ptr<Condition>>());
@@ -1201,6 +1204,37 @@ ENUM_DECODER(On, "action event (on)", (std::unordered_map<QString, On> {
     {"end_cancel", On::EndCancel}
 }))
 ENUM_DECODER(CursorShape, "cursor shape", CURSOR_SHAPES)
+ENUM_DECODER(Qt::MouseButton, "mouse button", (std::unordered_map<QString, Qt::MouseButton> {
+    {"left", Qt::MouseButton::LeftButton},
+    {"middle", Qt::MouseButton::MiddleButton},
+    {"right", Qt::MouseButton::RightButton},
+    {"back", Qt::MouseButton::ExtraButton1},
+    {"forward", Qt::MouseButton::ExtraButton2},
+    {"extra1", Qt::MouseButton::ExtraButton1},
+    {"extra2", Qt::MouseButton::ExtraButton2},
+    {"extra3", Qt::MouseButton::ExtraButton3},
+    {"extra4", Qt::MouseButton::ExtraButton4},
+    {"extra5", Qt::MouseButton::ExtraButton5},
+    {"extra6", Qt::MouseButton::ExtraButton6},
+    {"extra7", Qt::MouseButton::ExtraButton7},
+    {"extra8", Qt::MouseButton::ExtraButton8},
+    {"extra9", Qt::MouseButton::ExtraButton9},
+    {"extra10", Qt::MouseButton::ExtraButton10},
+    {"extra11", Qt::MouseButton::ExtraButton11},
+    {"extra12", Qt::MouseButton::ExtraButton12},
+    {"extra13", Qt::MouseButton::ExtraButton13},
+    {"extra14", Qt::MouseButton::ExtraButton14},
+    {"extra15", Qt::MouseButton::ExtraButton15},
+    {"extra16", Qt::MouseButton::ExtraButton16},
+    {"extra17", Qt::MouseButton::ExtraButton17},
+    {"extra18", Qt::MouseButton::ExtraButton18},
+    {"extra19", Qt::MouseButton::ExtraButton19},
+    {"extra20", Qt::MouseButton::ExtraButton20},
+    {"extra21", Qt::MouseButton::ExtraButton21},
+    {"extra22", Qt::MouseButton::ExtraButton22},
+    {"extra23", Qt::MouseButton::ExtraButton23},
+    {"extra24", Qt::MouseButton::ExtraButton24}
+}))
 ENUM_DECODER(PinchDirection, "pinch direction", (std::unordered_map<QString, PinchDirection> {
     {"in", PinchDirection::In},
     {"out", PinchDirection::Out},
@@ -1231,37 +1265,6 @@ FLAGS_DECODER(Qt::KeyboardModifiers, "keyboard modifier", (std::unordered_map<QS
     {"ctrl", Qt::KeyboardModifier::ControlModifier},
     {"meta", Qt::KeyboardModifier::MetaModifier},
     {"shift", Qt::KeyboardModifier::ShiftModifier}
-}))
-FLAGS_DECODER(Qt::MouseButtons, "mouse button", (std::unordered_map<QString, Qt::MouseButton> {
-    {"left", Qt::MouseButton::LeftButton},
-    {"middle", Qt::MouseButton::MiddleButton},
-    {"right", Qt::MouseButton::RightButton},
-    {"back", Qt::MouseButton::ExtraButton1},
-    {"forward", Qt::MouseButton::ExtraButton2},
-    {"extra1", Qt::MouseButton::ExtraButton1},
-    {"extra2", Qt::MouseButton::ExtraButton2},
-    {"extra3", Qt::MouseButton::ExtraButton3},
-    {"extra4", Qt::MouseButton::ExtraButton4},
-    {"extra5", Qt::MouseButton::ExtraButton5},
-    {"extra6", Qt::MouseButton::ExtraButton6},
-    {"extra7", Qt::MouseButton::ExtraButton7},
-    {"extra8", Qt::MouseButton::ExtraButton8},
-    {"extra9", Qt::MouseButton::ExtraButton9},
-    {"extra10", Qt::MouseButton::ExtraButton10},
-    {"extra11", Qt::MouseButton::ExtraButton11},
-    {"extra12", Qt::MouseButton::ExtraButton12},
-    {"extra13", Qt::MouseButton::ExtraButton13},
-    {"extra14", Qt::MouseButton::ExtraButton14},
-    {"extra15", Qt::MouseButton::ExtraButton15},
-    {"extra16", Qt::MouseButton::ExtraButton16},
-    {"extra17", Qt::MouseButton::ExtraButton17},
-    {"extra18", Qt::MouseButton::ExtraButton18},
-    {"extra19", Qt::MouseButton::ExtraButton19},
-    {"extra20", Qt::MouseButton::ExtraButton20},
-    {"extra21", Qt::MouseButton::ExtraButton21},
-    {"extra22", Qt::MouseButton::ExtraButton22},
-    {"extra23", Qt::MouseButton::ExtraButton23},
-    {"extra24", Qt::MouseButton::ExtraButton24}
 }))
 
 template<>

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -966,8 +966,8 @@ struct convert<std::unique_ptr<Trigger>>
         if (const auto &mouseButtonsNode = node["mouse_buttons"]) {
             trigger->setMouseButtons(mouseButtonsNode.as<std::vector<Qt::MouseButton>>());
         }
-        if (const auto &mouseButtonsNode = node["mouse_button_order_matters"]) {
-            trigger->setMouseButtonOrderMatters(mouseButtonsNode.as<bool>());
+        if (const auto &mouseButtonsExactOrderNode = node["mouse_buttons_exact_order"]) {
+            trigger->setMouseButtonsExactOrder(mouseButtonsExactOrderNode.as<bool>());
         }
         if (const auto &conditionsNode = node["conditions"]) {
             conditionGroup->add(conditionsNode.as<std::shared_ptr<Condition>>());

--- a/tests/libinputactions/triggers/TestTrigger.cpp
+++ b/tests/libinputactions/triggers/TestTrigger.cpp
@@ -64,7 +64,7 @@ void TestTrigger::canActivate()
     auto trigger = std::make_unique<Trigger>();
     auto event = std::make_unique<TriggerActivationEvent>();
     trigger->setMouseButtons(triggerButtons.value());
-    trigger->setMouseButtonOrderMatters(orderMatters);
+    trigger->setMouseButtonsExactOrder(orderMatters);
     event->mouseButtons = eventButtons;
     QCOMPARE(trigger->canActivate(event.get()), result);
 }

--- a/tests/libinputactions/triggers/TestTrigger.cpp
+++ b/tests/libinputactions/triggers/TestTrigger.cpp
@@ -52,6 +52,11 @@ void TestTrigger::canActivate_data()
 
     QTest::newRow("17") << leftRight << rightLeft << true << false;
     QTest::newRow("18") << rightLeft << leftRight << true << false;
+
+    QTest::newRow("19") << none << unset << false << true;
+    QTest::newRow("20") << none << left << false << true;
+    QTest::newRow("21") << none << unset << true << true;
+    QTest::newRow("22") << none << left << true << true;
 }
 
 void TestTrigger::canActivate()


### PR DESCRIPTION
New property: *Gesture.mouse_buttons_exact_order*