### PR TITLE
AUR package was renamed

### DIFF
--- a/src/kwin/README.md
+++ b/src/kwin/README.md
@@ -10,9 +10,9 @@ Minimum Plasma version: 6.1, mouse gestures require 6.3
 
   **Always choose *cleanBuild* when reinstalling the package.**
 
-  https://aur.archlinux.org/packages/input-actions
+  https://aur.archlinux.org/packages/inputactions-kwin
   ```
-  yay -S input-actions
+  yay -S inputactions-kwin
   ```
 </details>
 <details>


### PR DESCRIPTION
Hello,

I am the maintainer of the AUR package linked in the kwin-README. renamed the AUR package in order to conform to the naming of the official NixOS flake and to make the relation between that package and possible future inputactions-hyprland and inputactions-standalone clearer.

(As a sidenote I looked into creating a PKGBUILD for inputaction-hyprland, but I think using hyprpm is preferable so I didn't)