### PR TITLE
libinputactions: don't leak file descriptors to child processes

### DIFF
--- a/src/libinputactions/Config.cpp
+++ b/src/libinputactions/Config.cpp
@@ -76,6 +76,7 @@ Config::Config(InputBackend *backend)
         qWarning(INPUTACTIONS, "Failed to initialize config watcher");
         return;
     }
+    fcntl(m_inotifyFd, F_SETFD, FD_CLOEXEC);
     if (fcntl(m_inotifyFd, F_SETFL, fcntl(m_inotifyFd, F_GETFL, 0) | O_NONBLOCK) < 0) {
         qWarning(INPUTACTIONS, "Failed to initialize config watcher (fcntl failed)");
         return;

--- a/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
@@ -58,6 +58,7 @@ std::unique_ptr<LibevdevDevice> LibevdevComplementaryInputBackend::openDevice(co
                     << QString("Failed to open %1 (error %2)").arg(QString::fromStdString(path), QString::number(errno));
         return {};
     }
+    fcntl(device->fd, F_SETFD, FD_CLOEXEC);
 
     if (libevdev_new_from_fd(device->fd, &device->libevdevPtr) != 0) {
         device->libevdevPtr = nullptr;


### PR DESCRIPTION
The descriptors that were being leaked to processes spawned with the command action were the inotify fd (used for watching the config file and directory) and touchpad fds (only if the udev rule was created, in which case any program could open the device). Nothing that would require an immediate release.