### PR TITLE
{libinputactions,kwin}: add InputEmitter::keyboardText

### DIFF
--- a/src/kwin/interfaces/KWinInputEmitter.h
+++ b/src/kwin/interfaces/KWinInputEmitter.h
@@ -59,6 +59,7 @@ public:
 
     void keyboardClearModifiers() override;
     void keyboardKey(const uint32_t &key, const bool &state) override;
+    void keyboardText(const QString &text) override;
 
     void mouseButton(const uint32_t &button, const bool &state) override;
     void mouseMoveRelative(const QPointF &pos) override;

--- a/src/kwin/textinput.h
+++ b/src/kwin/textinput.h
@@ -1,0 +1,150 @@
+/*
+    SPDX-FileCopyrightText: 2020 Bhushan Shah <bshah@kde.org>
+
+    SPDX-License-Identifier: LGPL-2.1-only OR LGPL-3.0-only OR LicenseRef-KDE-Accepted-LGPL
+*/
+// TODO This header is currently not installed by KWin (https://invent.kde.org/plasma/kwin/-/merge_requests/7886)
+#pragma once
+
+#include <QMetaType>
+#include <QtGlobal>
+
+namespace KWin
+{
+
+/**
+ * ContentHint allows to modify the behavior of the text input.
+ */
+enum class TextInputContentHint {
+    /**
+     * no special behaviour
+     */
+    None = 0,
+    /**
+     * suggest word completions
+     */
+    AutoCompletion = 1 << 0,
+    /**
+     * suggest word corrections
+     */
+    AutoCorrection = 1 << 1,
+    /**
+     * switch to uppercase letters at the start of a sentence
+     */
+    AutoCapitalization = 1 << 2,
+    /**
+     * prefer lowercase letters
+     */
+    LowerCase = 1 << 3,
+    /**
+     * prefer uppercase letters
+     */
+    UpperCase = 1 << 4,
+    /**
+     * prefer casing for titles and headings (can be language dependent)
+     */
+    TitleCase = 1 << 5,
+    /**
+     * characters should be hidden
+     */
+    HiddenText = 1 << 6,
+    /**
+     * typed text should not be stored
+     */
+    SensitiveData = 1 << 7,
+    /**
+     * just latin characters should be entered
+     */
+    Latin = 1 << 8,
+    /**
+     * the text input is multi line
+     */
+    MultiLine = 1 << 9,
+};
+
+Q_DECLARE_FLAGS(TextInputContentHints, TextInputContentHint)
+
+/**
+ * The ContentPurpose allows to specify the primary purpose of a text input.
+ *
+ * This allows an input method to show special purpose input panels with
+ * extra characters or to disallow some characters.
+ */
+enum class TextInputContentPurpose {
+    /**
+     * default input, allowing all characters
+     */
+    Normal,
+    /**
+     * allow only alphabetic characters
+     */
+    Alpha,
+    /**
+     * allow only digits
+     */
+    Digits,
+    /**
+     * input a number (including decimal separator and sign)
+     */
+    Number,
+    /**
+     * input a phone number
+     */
+    Phone,
+    /**
+     * input an URL
+     */
+    Url,
+    /**
+     * input an email address
+     */
+    Email,
+    /**
+     * input a name of a person
+     */
+    Name,
+    /**
+     * input a password
+     */
+    Password,
+    /**
+     * input a date
+     */
+    Date,
+    /**
+     * input a time
+     */
+    Time,
+    /**
+     * input a date and time
+     */
+    DateTime,
+    /**
+     * input for a terminal
+     */
+    Terminal,
+    /**
+     * input is numeric password
+     */
+    Pin,
+};
+
+enum class TextInputChangeCause {
+    /**
+     * Change caused by input method
+     */
+    InputMethod,
+
+    /**
+     * Something else other than input method caused change
+     */
+    Other,
+};
+}
+
+Q_DECLARE_METATYPE(KWin::TextInputContentHint)
+Q_DECLARE_METATYPE(KWin::TextInputContentHints)
+Q_DECLARE_OPERATORS_FOR_FLAGS(KWin::TextInputContentHints)
+Q_DECLARE_METATYPE(KWin::TextInputContentPurpose)
+Q_DECLARE_METATYPE(KWin::TextInputChangeCause)
+

--- a/src/libinputactions/actions/InputTriggerAction.cpp
+++ b/src/libinputactions/actions/InputTriggerAction.cpp
@@ -33,6 +33,10 @@ void InputTriggerAction::execute()
         for (const auto &key : action.keyboardRelease) {
             input->keyboardKey(key, false);
         }
+        const auto keyboardText = action.keyboardText.get();
+        if (!keyboardText.isEmpty()) {
+            input->keyboardText(keyboardText);
+        }
 
         for (const auto &button : action.mousePress) {
             input->mouseButton(button, true);

--- a/src/libinputactions/actions/InputTriggerAction.h
+++ b/src/libinputactions/actions/InputTriggerAction.h
@@ -18,6 +18,8 @@
 
 #include "TriggerAction.h"
 
+#include <libinputactions/Value.h>
+
 #include <linux/input-event-codes.h>
 
 #include <map>
@@ -34,6 +36,7 @@ struct InputAction
 {
     std::vector<uint32_t> keyboardPress;
     std::vector<uint32_t> keyboardRelease;
+    Value<QString> keyboardText;
 
     std::vector<uint32_t> mousePress;
     std::vector<uint32_t> mouseRelease;

--- a/src/libinputactions/interfaces/InputEmitter.cpp
+++ b/src/libinputactions/interfaces/InputEmitter.cpp
@@ -25,6 +25,10 @@ void InputEmitter::keyboardClearModifiers()
 {
 }
 
+void InputEmitter::keyboardText(const QString &text)
+{
+}
+
 void InputEmitter::keyboardKey(const uint32_t &key, const bool &state)
 {
 }

--- a/src/libinputactions/interfaces/InputEmitter.h
+++ b/src/libinputactions/interfaces/InputEmitter.h
@@ -40,6 +40,7 @@ public:
      * @param state True - press, false - release
      */
     virtual void keyboardKey(const uint32_t &key, const bool &state);
+    virtual void keyboardText(const QString &text);
 
     /**
      * @param button <linux/input-event-codes.h>


### PR DESCRIPTION
This makes it possible to write text into input fields of clients that support the Text Input protocol.
```yaml
input:
  - keyboard: [ text: "asdasdasd!!!!!" ]
```

KWin only for now and for some reason key events are always handled after text but that's good enough for what I want.