### PR TITLE
libinputactions: add command value source

### DIFF
--- a/src/libinputactions/Value.cpp
+++ b/src/libinputactions/Value.cpp
@@ -21,8 +21,19 @@
 #include <libinputactions/globals.h>
 #include <libinputactions/variables/VariableManager.h>
 
+#include <QProcess>
+
 namespace libinputactions
 {
+
+template<typename T>
+T fromString(const QString &s);
+
+template<>
+QString fromString(const QString &s)
+{
+    return s;
+}
 
 template<typename T>
 Value<T>::Value(const T &value)
@@ -34,6 +45,19 @@ template<typename T>
 Value<T>::Value(const std::function<T()> &getter)
 {
     m_value = getter;
+}
+
+template<typename T>
+Value<T> Value<T>::command(const Value<QString> &command)
+{
+    return Value<T>([command] {
+        QProcess process;
+        process.setProgram("/bin/sh");
+        process.setArguments({"-c", command.get()});
+        process.start();
+        process.waitForFinished();
+        return fromString<T>(process.readAllStandardOutput());
+    });
 }
 
 template<typename T>

--- a/src/libinputactions/Value.h
+++ b/src/libinputactions/Value.h
@@ -35,6 +35,8 @@ public:
     Value(const T &value = {});
     Value(const std::function<T()> &getter);
     Value(const Expression<T> &expression);
+
+    static Value<T> command(const Value<QString> &command);
     static Value<T> variable(const QString &name);
 
     T get() const;

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -1416,12 +1416,18 @@ struct convert<libinputactions::Value<T>>
 {
     static bool decode(const Node &node, libinputactions::Value<T> &value)
     {
-        const auto raw = node.as<QString>();
-        // TODO Variable reference only
-        if (typeid(T) == typeid(QString)) { // String with possible variable references (too lazy to check)
-            value = libinputactions::Value<T>(Expression<QString>(raw));
+        if (node.IsMap()) {
+            if (const auto &commandNode = node["command"]) {
+                value = libinputactions::Value<T>::command(commandNode.as<libinputactions::Value<QString>>());
+            }
         } else {
-            value = libinputactions::Value<T>(node.as<T>());
+            const auto raw = node.as<QString>();
+            // TODO Variable reference only
+            if (typeid(T) == typeid(QString)) { // String with possible variable references (too lazy to check)
+                value = libinputactions::Value<T>(Expression<QString>(raw));
+            } else {
+                value = libinputactions::Value<T>(node.as<T>());
+            }
         }
         return true;
     }


### PR DESCRIPTION
This allows for the usage of a command's output as a value source for properties that allow non-hardcoded values. Slow commands will freeze the compositor, which will be fixed in the future by implementing asynchronous action execution.

Example:
```yaml
touchpad:
  gestures:
    - type: hold
      fingers: 2

      actions:
        - on: end
          input:
            - keyboard:
                - text:
                    command: date
```