### PR TITLE
hyprland: fix crash in HyprlandWindow::id

### DIFF
--- a/src/hyprland/interfaces/HyprlandWindow.cpp
+++ b/src/hyprland/interfaces/HyprlandWindow.cpp
@@ -26,7 +26,7 @@ HyprlandWindow::HyprlandWindow(CWindow *window)
 
 std::optional<QString> HyprlandWindow::id()
 {
-    return QString::fromStdString(std::format("{:x}", (uintptr_t)m_window));
+    return QString::number((uintptr_t)m_window, 16);
 }
 
 std::optional<QRectF> HyprlandWindow::geometry()


### PR DESCRIPTION
This used to work before, now it's crashing in std::format for some reason and I have no idea why.

```
Stack trace of thread 74838:
#0  0x00007fde8c69cf3c __pthread_kill_implementation (libc.so.6 + 0x9cf3c)
#1  0x00007fde8c64190e raise (libc.so.6 + 0x4190e)
#2  0x00007fde8c628942 abort (libc.so.6 + 0x28942)
#3  0x000000000067d0d3 _ZL25handleUnrecoverableSignali (/nix/store/fpzf4pv6h7vhcqaw4hss16khzy4xvn8w-hyprland-0.50.0/bin/.Hyprland-wrapped + 0x47d0d3)
#4  0x00007fde8c6419c0 __restore_rt (libc.so.6 + 0x419c0)
#5  0x00000000006e11c6 _ZNSt8__format19_Formatting_scannerINS_10_Sink_iterIcEEcE13_M_format_argEm (/nix/store/fpzf4pv6h7vhcqaw4hss16khzy4xvn8w-hyprland-0.50.0/bin/.Hyprland-wrapped + 0x4e11c6)
#6  0x00007fde5b2b4a16 _ZNSt8__format8_ScannerIcE23_M_on_replacement_fieldEv (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0x8da16)
#7  0x00007fde5b2b3dda _ZNSt8__format15__do_vformat_toINS_10_Sink_iterIcEEcSt20basic_format_contextIS2_cEEET_S5_St17basic_string_viewIT0_St11char_traitsIS7_EERKSt17basic_format_argsIT1_EPKSt6locale (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0x8cdda)
#8  0x00007fde5b2d8954 operator()<std::optional<QString> > (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0xb1954)
#9  0x00007fde5b2c8edd _ZNKSt8functionIFvRSt8optionalI7QStringEEEclES3_ (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0xa1edd)
#10 0x00007fde5b2d6111 _ZNKSt8functionIFvRSt3anyEEclES1_ (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0xaf111)
#11 0x00007fde5b323479 _ZNK15libinputactions22VariableOperationsBase8toStringEv (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0xfc479)
#12 0x00007fde5b326cbb _ZN15libinputactions13DBusInterface9variablesE7QString (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0xffcbb)
#13 0x00007fde5b310c1d _ZN15libinputactions13DBusInterface18qt_static_metacallEP7QObjectN11QMetaObject4CallEiPPv (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0xe9c1d)
#14 0x00007fde5b310f02 _ZN15libinputactions13DBusInterface11qt_metacallEN11QMetaObject4CallEiPPv (/home/marcin/Projects/kwin-gestures/build/lib/inputactions_hyprland.so + 0xe9f02)
```