### PR TITLE
libinputactions/actions/command: add wait property

### DIFF
--- a/src/libinputactions/actions/CommandAction.h
+++ b/src/libinputactions/actions/CommandAction.h
@@ -19,20 +19,30 @@
 #pragma once
 
 #include "Action.h"
+#include <QObject>
 #include <libinputactions/Value.h>
 
 namespace libinputactions
 {
 
 /**
- * Executes a command in a separate thread (neither main nor action).
+ * Executes a command in a shell.
  */
-class CommandAction : public Action
+class CommandAction
+    : public QObject
+    , public Action
 {
+    Q_OBJECT
+
 public:
     CommandAction(Value<QString> command);
 
     bool async() const override;
+
+    /**
+     * Whether to wait for the shell process to exit.
+     */
+    bool m_wait{};
 
 protected:
     void executeImpl() override;

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -1014,7 +1014,11 @@ struct convert<std::shared_ptr<Action>>
     static bool decode(const Node &node, std::shared_ptr<Action> &value)
     {
         if (const auto &commandNode = node["command"]) {
-            value = std::make_shared<CommandAction>(commandNode.as<libinputactions::Value<QString>>());
+            auto action = std::make_shared<CommandAction>(commandNode.as<libinputactions::Value<QString>>());
+            if (const auto &waitNode = node["wait"]) {
+                action->m_wait = waitNode.as<bool>();
+            }
+            value = action;
         } else if (const auto &inputNode = node["input"]) {
             auto action = std::make_shared<InputAction>(inputNode.as<std::vector<InputAction::Item>>());
             if (const auto &delayNode = node["delay"]) {


### PR DESCRIPTION
Allows for blocking action execution until the shell exits. Some programs may not work as expected if many instances are launched at once, which can happen if a gesture with a repeating action is performed quickly.