### PR TITLE
libinputactions: drop EventHandler.{blacklist,whitelist}

### DIFF
--- a/src/libinputactions/input/InputEventHandler.cpp
+++ b/src/libinputactions/input/InputEventHandler.cpp
@@ -21,37 +21,14 @@
 namespace libinputactions
 {
 
+InputEventHandler::InputEventHandler(std::unique_ptr<TriggerHandler> triggerHandler)
+    : m_triggerHandler(std::move(triggerHandler))
+{
+}
+
 bool InputEventHandler::handleEvent(const InputEvent &event)
 {
-    if (!m_triggerHandler || !matchesDevice(event.sender()->name())) {
-        return false;
-    }
     return m_triggerHandler->handleEvent(event);
-}
-
-bool InputEventHandler::matchesDevice(const QString &name) const
-{
-    if (!m_deviceNameWhitelist.empty()) {
-        return m_deviceNameWhitelist.contains(name);
-    } else if (!m_deviceNameBlacklist.empty()) {
-        return !m_deviceNameBlacklist.contains(name);
-    }
-    return true;
-}
-
-void InputEventHandler::setDeviceNameBlacklist(const std::set<QString> &blacklist)
-{
-    m_deviceNameBlacklist = blacklist;
-}
-
-void InputEventHandler::setDeviceNameWhitelist(const std::set<QString> &whitelist)
-{
-    m_deviceNameWhitelist = whitelist;
-}
-
-void InputEventHandler::setTriggerHandler(std::unique_ptr<TriggerHandler> handler)
-{
-    m_triggerHandler = std::move(handler);
 }
 
 }

--- a/src/libinputactions/input/InputEventHandler.h
+++ b/src/libinputactions/input/InputEventHandler.h
@@ -27,36 +27,19 @@ namespace libinputactions
 {
 
 /**
- * Handles device input events. Can handle multiple devices of different types.
+ * The point of this class is to remove the need to rewrite everything if remapping is added.
  */
 class InputEventHandler
 {
 public:
+    InputEventHandler(std::unique_ptr<TriggerHandler> triggerHandler);
+
     /**
-     * @return Whether the event should be blocked. False if trigger handler had not been set or the device name
-     * doesn't match.
+     * @return Whether the event should be blocked.
      */
     bool handleEvent(const InputEvent &event);
 
-    /**
-     * Mutually exclusive with setDeviceNameWhitelist.
-     * @param blacklist Devices to be ignored.
-     */
-    void setDeviceNameBlacklist(const std::set<QString> &blacklist);
-    /**
-     * Mutually exclusive with setDeviceNameBlacklist.
-     * @param whitelist Devices to not be ignored.
-     */
-    void setDeviceNameWhitelist(const std::set<QString> &whitelist);
-
-    void setTriggerHandler(std::unique_ptr<TriggerHandler> handler);
-
 private:
-    bool matchesDevice(const QString &name) const;
-
-    std::set<QString> m_deviceNameBlacklist;
-    std::set<QString> m_deviceNameWhitelist;
-
     std::unique_ptr<TriggerHandler> m_triggerHandler;
 };
 

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -802,46 +802,23 @@ struct convert<std::set<T>>
 };
 
 template<>
-struct convert<std::unique_ptr<InputEventHandler>>
-{
-    static bool decode(const Node &node, std::unique_ptr<InputEventHandler> &handler)
-    {
-        handler = std::make_unique<InputEventHandler>();
-        if (const auto &blacklistNode = node["blacklist"]) {
-            handler->setDeviceNameBlacklist(blacklistNode.as<std::set<QString>>());
-        } else if (const auto &whitelistNode = node["whitelist"]) {
-            handler->setDeviceNameWhitelist(whitelistNode.as<std::set<QString>>());
-        }
-        return true;
-    }
-};
-
-template<>
 struct convert<std::vector<std::unique_ptr<InputEventHandler>>>
 {
-    template<typename T>
-    static std::unique_ptr<InputEventHandler> decodeHandler(const Node &node)
-    {
-        auto result = node.as<std::unique_ptr<InputEventHandler>>();
-        result->setTriggerHandler(node.as<std::unique_ptr<T>>());
-        return result;
-    }
-
     static bool decode(const Node &node, std::vector<std::unique_ptr<InputEventHandler>> &handlers)
     {
         if (const auto &mouseNode = node["keyboard"]) {
             for (const auto &keyboardHandler : asSequence(mouseNode)) {
-                handlers.push_back(decodeHandler<KeyboardTriggerHandler>(keyboardHandler));
+                handlers.push_back(std::make_unique<InputEventHandler>(keyboardHandler.as<std::unique_ptr<KeyboardTriggerHandler>>()));
             }
         }
         if (const auto &mouseNode = node["mouse"]) {
             for (const auto &mouseHandler : asSequence(mouseNode)) {
-                handlers.push_back(decodeHandler<MouseTriggerHandler>(mouseHandler));
+                handlers.push_back(std::make_unique<InputEventHandler>(mouseHandler.as<std::unique_ptr<MouseTriggerHandler>>()));
             }
         }
         if (const auto &touchpadNode = node["touchpad"]) {
             for (const auto &touchpadHandler : asSequence(touchpadNode)) {
-                handlers.push_back(decodeHandler<TouchpadTriggerHandler>(touchpadHandler));
+                handlers.push_back(std::make_unique<InputEventHandler>(touchpadHandler.as<std::unique_ptr<TouchpadTriggerHandler>>()));
             }
         }
         return true;


### PR DESCRIPTION
Removes *[EventHandler](https://wiki.inputactions.org/v0.7.0/config.html#eventhandler).blacklist* and *whitelist*, see property description for alternative.