### PR TITLE
libinputactions/touchpad: implement tap gesture

### DIFF
--- a/src/libinputactions/globals.h
+++ b/src/libinputactions/globals.h
@@ -48,6 +48,7 @@ enum class TriggerType : uint32_t
     Swipe = 1u << 5,
     Wheel = 1u << 6,
     KeyboardShortcut = 1u << 7,
+    Tap = 1u << 8,
 
     PinchRotate = Pinch | Rotate,
     StrokeSwipe = Stroke | Swipe,

--- a/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.cpp
@@ -17,11 +17,32 @@
 */
 
 #include "MultiTouchMotionTriggerHandler.h"
+#include <libinputactions/variables/VariableManager.h>
 
 Q_LOGGING_CATEGORY(INPUTACTIONS_HANDLER_MULTITOUCH, "inputactions.handler.multitouch", QtWarningMsg)
 
 namespace libinputactions
 {
+
+bool MultiTouchMotionTriggerHandler::handleEvent(const InputEvent &event)
+{
+    if (TriggerHandler::handleEvent(event)) {
+        return true;
+    }
+
+    switch (event.type()) {
+        case InputEventType::TouchDown:
+            handleTouchDownEvent(static_cast<const TouchEvent &>(event));
+            break;
+        case InputEventType::TouchChanged:
+            handleEvent(static_cast<const TouchChangedEvent &>(event));
+            break;
+        case InputEventType::TouchUp:
+            handleTouchUpEvent(static_cast<const TouchEvent &>(event));
+            break;
+    }
+    return false;
+}
 
 bool MultiTouchMotionTriggerHandler::handlePinch(qreal scale, qreal angleDelta)
 {
@@ -91,6 +112,104 @@ void MultiTouchMotionTriggerHandler::reset()
     m_previousPinchScale = 1;
     m_pinchType = PinchType::Unknown;
     m_accumulatedRotateDelta = 0;
+}
+
+void MultiTouchMotionTriggerHandler::handleTouchDownEvent(const TouchEvent &event)
+{
+    switch (m_state) {
+        case State::None:
+            m_state = State::TouchIdle;
+            break;
+    }
+    updateVariables(event.sender());
+}
+
+void MultiTouchMotionTriggerHandler::handleEvent(const TouchChangedEvent &event)
+{
+    switch (m_state) {
+        case State::TouchIdle:
+            const auto diff = event.point().position - event.point().initialPosition;
+            if (std::hypot(diff.x(), diff.y()) >= 0.02) {
+                m_state = State::Touch;
+            }
+            break;
+    }
+    updateVariables(event.sender());
+}
+
+void MultiTouchMotionTriggerHandler::handleTouchUpEvent(const TouchEvent &event)
+{
+    switch (m_state) {
+        case State::TapBegin:
+        case State::TouchIdle:
+            if (canTap(event.sender())) {
+                if (m_state == State::TouchIdle) {
+                    m_state = activateTriggers(TriggerType::Tap) ? State::TapBegin : State::Touch;
+                }
+                if (m_state == State::TapBegin && !event.sender()->validTouchPoints()) {
+                    updateTriggers(TriggerType::Tap);
+                    endTriggers(TriggerType::Tap);
+                    m_state = State::TapEnd;
+
+                    // Reset state manually if there is no click event
+                    QTimer::singleShot(50, [this]() {
+                        if (m_state == State::TapEnd) {
+                            m_state = State::None;
+                        }
+                    });
+                }
+            } else if (m_state == State::TapBegin) {
+                cancelTriggers(TriggerType::Tap);
+                m_state = State::TouchIdle;
+            }
+            break;
+    }
+    updateVariables(event.sender());
+
+    if (m_state != State::TapEnd && !event.sender()->validTouchPoints()) {
+        m_state = State::None;
+    }
+}
+
+bool MultiTouchMotionTriggerHandler::canTap(const InputDevice *device)
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - device->m_touchPoints[0].downTimestamp).count() <= 500;
+}
+
+void MultiTouchMotionTriggerHandler::updateVariables(const InputDevice *sender)
+{
+    auto thumbPresent = g_variableManager->getVariable(BuiltinVariables::ThumbPresent);
+    auto thumbPosition = g_variableManager->getVariable(BuiltinVariables::ThumbPositionPercentage);
+    bool hasThumb{};
+
+    for (auto i = 0; i < std::min(static_cast<uint8_t>(sender->m_touchPoints.size()), s_fingerVariableCount); i++) {
+        const auto &slot = sender->m_touchPoints[i];
+        const auto fingerVariableNumber = i + 1;
+
+        auto position = g_variableManager->getVariable<QPointF>(QString("finger_%1_position_percentage").arg(fingerVariableNumber));
+        auto pressure = g_variableManager->getVariable<qreal>(QString("finger_%1_pressure").arg(fingerVariableNumber));
+
+        if (!slot.valid) {
+            position->set({});
+            pressure->set({});
+            continue;
+        }
+
+        if (slot.type == TouchPointType::Thumb) {
+            hasThumb = true;
+            thumbPresent->set(true);
+            thumbPosition->set(slot.position);
+        }
+        position->set(slot.position);
+        pressure->set(slot.pressure);
+    }
+
+    if (!hasThumb) {
+        thumbPresent->set(false);
+        thumbPosition->set({});
+    }
+
+    g_variableManager->getVariable(BuiltinVariables::Fingers)->set(sender->validTouchPoints());
 }
 
 }

--- a/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.h
+++ b/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.h
@@ -38,6 +38,9 @@ enum class PinchType
  */
 class MultiTouchMotionTriggerHandler : public MotionTriggerHandler
 {
+public:
+    bool handleEvent(const InputEvent &event) override;
+
 protected:
     MultiTouchMotionTriggerHandler() = default;
 
@@ -49,7 +52,37 @@ protected:
 
     void reset() override;
 
+    enum State
+    {
+        TouchpadButtonDown,
+        TouchpadButtonUp,
+
+        None,
+        Scrolling,
+
+        /**
+         * Finger(s) present but no action had been performed other than adding more fingers.
+         */
+        TouchIdle,
+        /**
+         * Finger(s) present and an action had been performed.
+         */
+        Touch,
+
+        TapBegin,
+        TapEnd
+    } m_state
+        = State::None;
+    State m_savedState = State::None;
+
 private:
+    void handleTouchDownEvent(const TouchEvent &event);
+    void handleEvent(const TouchChangedEvent &event);
+    void handleTouchUpEvent(const TouchEvent &event);
+
+    bool canTap(const InputDevice *device);
+    void updateVariables(const InputDevice *device);
+
     qreal m_previousPinchScale = 1;
     PinchType m_pinchType = PinchType::Unknown;
     qreal m_accumulatedRotateDelta = 0;

--- a/src/libinputactions/handlers/TouchpadTriggerHandler.h
+++ b/src/libinputactions/handlers/TouchpadTriggerHandler.h
@@ -24,10 +24,7 @@ namespace libinputactions
 {
 
 /**
- * Handles touchpad triggers: click, pinch, press, rotate, stroke, swipe.
- *
- * Pinch triggers may not be detected correctly because libinput appears to be really bad at it. Five-finger triggers also do not work for some reason, even on
- * a touchpad with five slots.
+ * Handles touchpad triggers: click, pinch, press, rotate, stroke, swipe, tap.
  *
  * If the libevdev backend is not available, the finger count is fetched from libinput's gesture begin events and scroll events.
  */
@@ -46,20 +43,16 @@ public:
 
 private:
     bool handleEvent(const PointerButtonEvent &event);
-    bool handleEvent(const TouchpadClickEvent &event);
+    void handleEvent(const TouchpadClickEvent &event);
     bool handleEvent(const TouchpadGestureLifecyclePhaseEvent &event);
     bool handleEvent(const TouchpadPinchEvent &event);
-    bool handleEvent(const TouchpadSlotEvent &event);
     /**
      * The event is treated as two-finger motion. Will not work if edge scrolling is enabled.
      */
     bool handleScrollEvent(const MotionEvent &event);
     bool handleSwipeEvent(const MotionEvent &event);
 
-    bool m_scrollInProgress{};
-
     bool m_usesLibevdevBackend{};
-    bool m_clicked{};
 
     uint32_t m_clickTimeout = 200;
     QTimer m_clickTimeoutTimer;

--- a/src/libinputactions/handlers/TriggerHandler.h
+++ b/src/libinputactions/handlers/TriggerHandler.h
@@ -69,7 +69,7 @@ protected:
      * correctly.
      * @see updateTriggers(const std::map<TriggerType, const TriggerUpdateEvent *> &events)
      */
-    bool updateTriggers(TriggerType type, const TriggerUpdateEvent &event);
+    bool updateTriggers(TriggerType type, const TriggerUpdateEvent &event = {});
 
     /**
      * Ends the specified types of triggers.

--- a/src/libinputactions/input/InputDevice.cpp
+++ b/src/libinputactions/input/InputDevice.cpp
@@ -53,20 +53,27 @@ const InputDeviceProperties &InputDevice::properties() const
     return m_properties;
 }
 
+uint8_t InputDevice::validTouchPoints() const
+{
+    return std::ranges::count_if(m_touchPoints, [](const auto &point) {
+        return point.valid;
+    });
+}
+
 void InputDeviceProperties::apply(const InputDeviceProperties &other)
 {
-    if (other.m_multiTouch) {
-        m_multiTouch = other.m_multiTouch;
-    }
-    if (other.m_size) {
-        m_size = other.m_size;
-    }
-    if (other.m_buttonPad) {
-        m_buttonPad = other.m_buttonPad;
-    }
-    if (other.m_thumbPressureRange) {
-        m_thumbPressureRange = other.m_thumbPressureRange;
-    }
+    static const auto apply = [](auto &thisOpt, auto &otherOpt) {
+        if (otherOpt) {
+            thisOpt = otherOpt;
+        }
+    };
+
+    apply(m_multiTouch, other.m_multiTouch);
+    apply(m_size, other.m_size);
+    apply(m_buttonPad, other.m_buttonPad);
+    apply(m_fingerPressure, other.m_fingerPressure);
+    apply(m_thumbPressure, other.m_thumbPressure);
+    apply(m_palmPressure, other.m_palmPressure);
 }
 
 bool InputDeviceProperties::multiTouch() const
@@ -99,14 +106,34 @@ void InputDeviceProperties::setButtonPad(bool value)
     m_buttonPad = value;
 }
 
-Range<uint32_t> InputDeviceProperties::thumbPressureRange() const
+uint32_t InputDeviceProperties::fingerPressure() const
 {
-    return m_thumbPressureRange.value_or(Range<uint32_t>(-1, -1));
+    return m_fingerPressure.value_or(0);
 }
 
-void InputDeviceProperties::setThumbPressureRange(const Range<uint32_t> &value)
+void InputDeviceProperties::setFingerPressure(uint32_t value)
 {
-    m_thumbPressureRange = value;
+    m_fingerPressure = value;
+}
+
+uint32_t InputDeviceProperties::thumbPressure() const
+{
+    return m_thumbPressure.value_or(UINT32_MAX);
+}
+
+void InputDeviceProperties::setThumbPressure(uint32_t value)
+{
+    m_thumbPressure = value;
+}
+
+uint32_t InputDeviceProperties::palmPressure() const
+{
+    return m_palmPressure.value_or(UINT32_MAX);
+}
+
+void InputDeviceProperties::setPalmPressure(uint32_t value)
+{
+    m_palmPressure = value;
 }
 
 }

--- a/src/libinputactions/input/InputDevice.h
+++ b/src/libinputactions/input/InputDevice.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <QPointF>
 #include <QRegularExpression>
 #include <QSizeF>
 #include <libinputactions/Range.h>
@@ -64,15 +65,60 @@ public:
      */
     void setButtonPad(bool value);
 
-    Range<uint32_t> thumbPressureRange() const;
-    void setThumbPressureRange(const Range<uint32_t> &value);
+    uint32_t fingerPressure() const;
+    /**
+     * @param value Minimum pressure for a touch point to be considered a finger.
+     */
+    void setFingerPressure(uint32_t value);
+
+    uint32_t thumbPressure() const;
+    /**
+     * @param value Minimum pressure for a touch point to be considered a thumb.
+     */
+    void setThumbPressure(uint32_t value);
+
+    uint32_t palmPressure() const;
+    /**
+     * @param value Minimum pressure for a touch point to be considered a palm.
+     */
+    void setPalmPressure(uint32_t value);
 
 private:
     std::optional<bool> m_multiTouch;
     std::optional<QSizeF> m_size;
 
     std::optional<bool> m_buttonPad;
-    std::optional<Range<uint32_t>> m_thumbPressureRange;
+    std::optional<uint32_t> m_fingerPressure;
+    std::optional<uint32_t> m_thumbPressure;
+    std::optional<uint32_t> m_palmPressure;
+};
+
+enum TouchPointType
+{
+    None,
+    Finger,
+    Thumb,
+    Palm
+};
+
+struct TouchPoint
+{
+    /**
+     * Whether this touch point is active and fits within the pressure ranges.
+     */
+    bool valid{};
+    TouchPointType type = TouchPointType::None;
+
+    QPointF initialPosition;
+    QPointF position;
+    uint32_t pressure{};
+    std::chrono::steady_clock::time_point downTimestamp;
+
+    /**
+     * Whether this touch point is active.
+     * @internal
+     */
+    bool active{};
 };
 
 class InputDevice
@@ -89,6 +135,12 @@ public:
     const QString &sysName() const;
     InputDeviceProperties &properties();
     const InputDeviceProperties &properties() const;
+
+    /**
+     * The size of the vector is equal to the maximum slot count.
+     */
+    std::vector<TouchPoint> m_touchPoints;
+    uint8_t validTouchPoints() const;
 
 private:
     InputDeviceType m_type;

--- a/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
@@ -32,7 +32,7 @@ Q_LOGGING_CATEGORY(INPUTACTIONS_BACKEND_LIBEVDEV, "inputactions.input.backend.li
 LibevdevComplementaryInputBackend::LibevdevComplementaryInputBackend()
 {
     m_inputTimer.setTimerType(Qt::TimerType::PreciseTimer);
-    m_inputTimer.setInterval(100);
+    m_inputTimer.setInterval(10);
     QObject::connect(&m_inputTimer, &QTimer::timeout, [this] {
         poll();
     });
@@ -117,6 +117,7 @@ void LibevdevComplementaryInputBackend::deviceAdded(InputDevice *device)
         multiTouch = true;
         slotCount = libevdev_get_abs_maximum(libevdevDevice->libevdevPtr, ABS_MT_SLOT) + 1;
     }
+    device->m_touchPoints = std::vector<TouchPoint>(slotCount);
     qCDebug(INPUTACTIONS_BACKEND_LIBEVDEV).noquote().nospace()
         << "Found valid touchpad (size: " << size << ", multiTouch: " << multiTouch << ", slots: " << slotCount << ")";
 
@@ -125,7 +126,6 @@ void LibevdevComplementaryInputBackend::deviceAdded(InputDevice *device)
     properties.setMultiTouch(multiTouch);
     properties.setButtonPad(buttonPad);
 
-    libevdevDevice->fingerSlots = std::vector<TouchpadSlot>{slotCount};
     m_libevdevDevices[device] = std::move(libevdevDevice);
     m_inputTimer.start();
 }
@@ -153,6 +153,7 @@ void LibevdevComplementaryInputBackend::poll()
 
     input_event event;
     for (auto &[device, libevdevDevice] : m_libevdevDevices) {
+        const auto previousTouchPoints = device->m_touchPoints;
         const auto &properties = device->properties();
         int status{};
         while (true) {
@@ -167,32 +168,36 @@ void LibevdevComplementaryInputBackend::poll()
             switch (event.type) {
                 case EV_SYN:
                     if (code == SYN_REPORT) {
-                        handleEvent(TouchpadSlotEvent(device, libevdevDevice->fingerSlots));
+                        for (size_t i = 0; i < previousTouchPoints.size(); i++) {
+                            const auto &previous = previousTouchPoints[i];
+                            auto &slot = device->m_touchPoints[i];
 
-                        static const std::map<uint16_t, uint8_t> fingerCountCodes = {
-                            {0, 0},
-                            {BTN_TOOL_FINGER, 1},
-                            {BTN_TOOL_DOUBLETAP, 2},
-                            {BTN_TOOL_TRIPLETAP, 3},
-                            {BTN_TOOL_QUADTAP, 4},
-                            {BTN_TOOL_QUINTTAP, 5},
-                        };
-                        g_variableManager->getVariable(BuiltinVariables::Fingers)->set(fingerCountCodes.at(libevdevDevice->currentFingerCode));
+                            if (slot.pressure >= device->properties().palmPressure()) {
+                                slot.type = TouchPointType::Palm;
+                            } else if (slot.pressure >= device->properties().thumbPressure()) {
+                                slot.type = TouchPointType::Thumb;
+                            } else if (slot.pressure >= device->properties().fingerPressure()) {
+                                slot.type = TouchPointType::Finger;
+                            } else {
+                                slot.type = TouchPointType::None;
+                            }
+                            slot.valid = slot.active && (slot.type == TouchPointType::Finger || slot.type == TouchPointType::Thumb);
+
+                            if (previous.valid != slot.valid) {
+                                if (slot.valid) {
+                                    slot.downTimestamp = std::chrono::steady_clock::now();
+                                    slot.initialPosition = slot.position;
+                                }
+
+                                handleEvent(TouchEvent(device, slot.valid ? InputEventType::TouchDown : InputEventType::TouchUp, slot));
+                            } else if (previous.position != slot.position || previous.pressure != slot.pressure) {
+                                handleEvent(TouchChangedEvent(device, slot, slot.position - previous.position, slot.pressure - previous.pressure));
+                            }
+                        }
                     }
                     continue;
                 case EV_KEY:
                     switch (code) {
-                        case BTN_TOOL_FINGER:
-                        case BTN_TOOL_DOUBLETAP:
-                        case BTN_TOOL_TRIPLETAP:
-                        case BTN_TOOL_QUADTAP:
-                        case BTN_TOOL_QUINTTAP:
-                            if (value == 1) {
-                                libevdevDevice->currentFingerCode = code;
-                            } else if (value == 0 && libevdevDevice->currentFingerCode == code) {
-                                libevdevDevice->currentFingerCode = 0;
-                            }
-                            continue;
                         case BTN_LEFT:
                         case BTN_MIDDLE:
                         case BTN_RIGHT:
@@ -203,35 +208,35 @@ void LibevdevComplementaryInputBackend::poll()
                     }
                     continue;
                 case EV_ABS:
-                    auto &currentSlot = libevdevDevice->fingerSlots[libevdevDevice->currentSlot];
+                    auto &currentTouchPoint = device->m_touchPoints[libevdevDevice->currentSlot];
                     if (properties.multiTouch()) {
                         switch (code) {
                             case ABS_MT_SLOT:
                                 libevdevDevice->currentSlot = value;
                                 continue;
                             case ABS_MT_TRACKING_ID:
-                                currentSlot.active = value != -1;
+                                currentTouchPoint.active = value != -1;
                                 continue;
                             case ABS_MT_POSITION_X:
-                                currentSlot.position.setX(value / properties.size().width());
+                                currentTouchPoint.position.setX(value / properties.size().width());
                                 continue;
                             case ABS_MT_POSITION_Y:
-                                currentSlot.position.setY(value / properties.size().height());
+                                currentTouchPoint.position.setY(value / properties.size().height());
                                 continue;
                             case ABS_MT_PRESSURE:
-                                currentSlot.pressure = value;
+                                currentTouchPoint.pressure = value;
                                 continue;
                         }
                     } else {
                         switch (code) {
                             case ABS_X:
-                                currentSlot.position.setX(value / properties.size().width());
+                                currentTouchPoint.position.setX(value / properties.size().width());
                                 continue;
                             case ABS_Y:
-                                currentSlot.position.setY(value / properties.size().height());
+                                currentTouchPoint.position.setY(value / properties.size().height());
                                 continue;
                             case ABS_PRESSURE:
-                                currentSlot.pressure = value;
+                                currentTouchPoint.pressure = value;
                                 continue;
                         }
                     }

--- a/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.h
+++ b/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.h
@@ -35,15 +35,7 @@ struct LibevdevDevice
     int fd = -1;
     QString name;
 
-    /**
-     * If device doesn't support MT type B protocol, only the first slot will be used.
-     */
-    std::vector<TouchpadSlot> fingerSlots;
     uint8_t currentSlot{};
-    /**
-     * 0, BTN_TOOL_FINGER, BTN_TOOL_DOUBLETAP, BTN_TOOL_TRIPLETAP, BTN_TOOL_QUADTAP or BTN_TOOL_QUINTTAP
-     */
-    uint16_t currentFingerCode{};
 };
 
 /**

--- a/src/libinputactions/input/events.cpp
+++ b/src/libinputactions/input/events.cpp
@@ -140,15 +140,32 @@ const uint8_t &TouchpadGestureLifecyclePhaseEvent::fingers() const
     return m_fingers;
 }
 
-TouchpadSlotEvent::TouchpadSlotEvent(InputDevice *sender, const std::vector<TouchpadSlot> &fingerSlots)
-    : InputEvent(InputEventType::TouchpadSlot, sender)
-    , m_slots(fingerSlots)
+TouchEvent::TouchEvent(InputDevice *sender, InputEventType type, TouchPoint point)
+    : InputEvent(type, sender)
+    , m_point(std::move(point))
 {
 }
 
-const std::vector<TouchpadSlot> &TouchpadSlotEvent::fingerSlots() const
+const TouchPoint &TouchEvent::point() const
 {
-    return m_slots;
+    return m_point;
+}
+
+TouchChangedEvent::TouchChangedEvent(InputDevice *sender, TouchPoint point, QPointF positionDelta, int8_t pressureDelta)
+    : TouchEvent(sender, InputEventType::TouchChanged, point)
+    , m_positionDelta(std::move(positionDelta))
+    , m_pressureDelta(pressureDelta)
+{
+}
+
+const QPointF &TouchChangedEvent::positionDelta() const
+{
+    return m_positionDelta;
+}
+
+uint8_t TouchChangedEvent::pressureDelta() const
+{
+    return m_pressureDelta;
 }
 
 }

--- a/src/libinputactions/input/events.h
+++ b/src/libinputactions/input/events.h
@@ -34,6 +34,10 @@ enum class InputEventType
     PointerMotion,
     PointerScroll,
 
+    TouchDown,
+    TouchChanged,
+    TouchUp,
+
     TouchpadClick,
     TouchpadGestureLifecyclePhase,
     TouchpadSlot,
@@ -142,22 +146,28 @@ private:
     uint8_t m_fingers;
 };
 
-struct TouchpadSlot
-{
-    bool active{};
-    QPointF position;
-    uint32_t pressure{};
-};
-
-class TouchpadSlotEvent : public InputEvent
+class TouchEvent : public InputEvent
 {
 public:
-    TouchpadSlotEvent(InputDevice *sender, const std::vector<TouchpadSlot> &fingerSlots);
+    TouchEvent(InputDevice *sender, InputEventType type, TouchPoint point);
 
-    const std::vector<TouchpadSlot> &fingerSlots() const;
+    const TouchPoint &point() const;
 
 private:
-    std::vector<TouchpadSlot> m_slots;
+    TouchPoint m_point;
+};
+
+class TouchChangedEvent : public TouchEvent
+{
+public:
+    TouchChangedEvent(InputDevice *sender, TouchPoint point, QPointF positionDelta, int8_t pressureDelta);
+
+    const QPointF &positionDelta() const;
+    uint8_t pressureDelta() const;
+
+private:
+    QPointF m_positionDelta;
+    int8_t m_pressureDelta;
 };
 
 }

--- a/src/libinputactions/yaml_convert.h
+++ b/src/libinputactions/yaml_convert.h
@@ -882,14 +882,16 @@ struct convert<std::unique_ptr<Trigger>>
             trigger.reset(pressTrigger);
         } else if (type == "pinch") {
             trigger = std::make_unique<DirectionalMotionTrigger>(TriggerType::Pinch, static_cast<TriggerDirection>(node["direction"].as<PinchDirection>()));
+        } else if (type == "rotate") {
+            trigger = std::make_unique<DirectionalMotionTrigger>(TriggerType::Rotate, static_cast<TriggerDirection>(node["direction"].as<RotateDirection>()));
         } else if (type == "shortcut") {
             trigger = std::make_unique<KeyboardShortcutTrigger>(node["shortcut"].as<KeyboardShortcut>());
         } else if (type == "stroke") {
             trigger = std::make_unique<StrokeTrigger>(asSequence(node["strokes"]).as<std::vector<Stroke>>());
         } else if (type == "swipe") {
             trigger = std::make_unique<DirectionalMotionTrigger>(TriggerType::Swipe, static_cast<TriggerDirection>(node["direction"].as<SwipeDirection>()));
-        } else if (type == "rotate") {
-            trigger = std::make_unique<DirectionalMotionTrigger>(TriggerType::Rotate, static_cast<TriggerDirection>(node["direction"].as<RotateDirection>()));
+        } else if (type == "tap") {
+            trigger = std::make_unique<Trigger>(TriggerType::Tap);
         } else if (type == "wheel") {
             trigger = std::make_unique<WheelTrigger>(static_cast<TriggerDirection>(node["direction"].as<SwipeDirection>()));
         } else {
@@ -1389,8 +1391,14 @@ struct convert<InputDeviceProperties>
             value.setButtonPad(buttonPad.as<bool>());
         }
         if (const auto &pressureRangesNode = node["pressure_ranges"]) {
+            if (const auto &fingerNode = pressureRangesNode["finger"]) {
+                value.setFingerPressure(fingerNode.as<uint32_t>());
+            }
             if (const auto &thumbNode = pressureRangesNode["thumb"]) {
-                value.setThumbPressureRange(thumbNode.as<Range<uint32_t>>());
+                value.setThumbPressure(thumbNode.as<uint32_t>());
+            }
+            if (const auto &palmNode = pressureRangesNode["palm"]) {
+                value.setPalmPressure(palmNode.as<uint32_t>());
             }
         }
         return true;


### PR DESCRIPTION
Type is ``tap``, supports 5 fingers and requires the [libevdev backend](https://wiki.inputactions.org/main/devices/touchpad.html#libevdev-backend).

The finger pressure threshold (see below) must be set manually, otherwise pointer button events will not be blocked properly for 1-, 2- and 3-finger tap gestures.

New properties: *[TouchpadProperties](https://wiki.inputactions.org/main/devices/touchpad.html#touchpadproperties).pressure_ranges.finger*, *TouchpadProperties.pressure_ranges.palm* (type is *uint* for both)
Changed properties: *TouchpadProperties.pressure_ranges.thumb* is now of type *uint* (breaking change)

closes #173 