### PR TITLE
libinputactions: don't make QProcess a child of CommandAction

### DIFF
--- a/src/libinputactions/actions/CommandAction.cpp
+++ b/src/libinputactions/actions/CommandAction.cpp
@@ -34,7 +34,7 @@ bool CommandAction::async() const
 
 void CommandAction::executeImpl()
 {
-    auto *process = new QProcess(this);
+    auto *process = new QProcess;
     connect(process, &QProcess::finished, this, [process]() {
         process->deleteLater();
     });


### PR DESCRIPTION
fixes #184