### PR TITLE
libinputactions: implement toString for point variables, hide _x and _y ones

### DIFF
--- a/src/libinputactions/DBusInterface.cpp
+++ b/src/libinputactions/DBusInterface.cpp
@@ -84,7 +84,7 @@ QString DBusInterface::variables(QString filter)
     QStringList result;
     const QRegularExpression filterRegex(filter);
     for (const auto &[name, variable] : g_variableManager->variables()) {
-        if (!filterRegex.match(name).hasMatch()) {
+        if (variable->m_hidden || !filterRegex.match(name).hasMatch()) {
             continue;
         }
         result.push_back(QString("%1: %2").arg(name, variable->operations()->toString()));

--- a/src/libinputactions/variables/Variable.h
+++ b/src/libinputactions/variables/Variable.h
@@ -51,6 +51,11 @@ public:
 
     const std::type_index &type() const;
 
+    /**
+     * Whether the value should not be shown in the DBus interface.
+     */
+    bool m_hidden{};
+
 private:
     std::type_index m_type;
     std::variant<bool, QString> m_value;

--- a/src/libinputactions/variables/VariableManager.cpp
+++ b/src/libinputactions/variables/VariableManager.cpp
@@ -130,16 +130,22 @@ VariableManager::VariableManager()
 
     for (const auto &[name, variable] : m_variables) {
         if (variable->type() == typeid(QPointF)) {
-            registerRemoteVariable<qreal>(name + "_x", [this, name](auto &value) {
-                if (const auto point = getVariable<QPointF>(name)->get()) {
-                    value = point->x();
-                }
-            });
-            registerRemoteVariable<qreal>(name + "_y", [this, name](auto &value) {
-                if (const auto point = getVariable<QPointF>(name)->get()) {
-                    value = point->y();
-                }
-            });
+            registerRemoteVariable<qreal>(
+                name + "_x",
+                [this, name](auto &value) {
+                    if (const auto point = getVariable<QPointF>(name)->get()) {
+                        value = point->x();
+                    }
+                },
+                true);
+            registerRemoteVariable<qreal>(
+                name + "_y",
+                [this, name](auto &value) {
+                    if (const auto point = getVariable<QPointF>(name)->get()) {
+                        value = point->y();
+                    }
+                },
+                true);
         }
     }
 }
@@ -155,8 +161,9 @@ Variable *VariableManager::getVariable(const QString &name)
     return m_variables.at(name).get();
 }
 
-void VariableManager::registerVariable(const QString &name, std::unique_ptr<Variable> variable)
+void VariableManager::registerVariable(const QString &name, std::unique_ptr<Variable> variable, bool hidden)
 {
+    variable->m_hidden = hidden;
     m_variables[name] = std::move(variable);
 }
 

--- a/src/libinputactions/variables/VariableManager.h
+++ b/src/libinputactions/variables/VariableManager.h
@@ -95,7 +95,7 @@ public:
      */
     Variable *getVariable(const QString &name);
 
-    void registerVariable(const QString &name, std::unique_ptr<Variable> variable);
+    void registerVariable(const QString &name, std::unique_ptr<Variable> variable, bool hidden = false);
     template<typename T>
     void registerLocalVariable(const QString &name)
     {
@@ -107,7 +107,7 @@ public:
         registerLocalVariable<T>(variable.name);
     }
     template<typename T>
-    void registerRemoteVariable(const QString &name, const std::function<void(std::optional<T> &value)> getter)
+    void registerRemoteVariable(const QString &name, const std::function<void(std::optional<T> &value)> getter, bool hidden = false)
     {
         const std::function<void(std::any & value)> anyGetter = [getter](std::any &value) {
             std::optional<T> optValue;
@@ -116,7 +116,7 @@ public:
                 value = optValue.value();
             }
         };
-        registerVariable(name, std::make_unique<RemoteVariable>(typeid(T), anyGetter));
+        registerVariable(name, std::make_unique<RemoteVariable>(typeid(T), anyGetter), hidden);
     }
 
     std::map<QString, const Variable *> variables() const;

--- a/src/libinputactions/variables/VariableOperations.cpp
+++ b/src/libinputactions/variables/VariableOperations.cpp
@@ -202,6 +202,12 @@ QString VariableOperations<CursorShape>::toString(const CursorShape &value)
 }
 
 template<>
+QString VariableOperations<QPointF>::toString(const QPointF &value)
+{
+    return QString("(%1, %2)").arg(value.x()).arg(value.y());
+}
+
+template<>
 QString VariableOperations<QString>::toString(const QString &value)
 {
     return value;


### PR DESCRIPTION
Makes the output of the ``variables`` DBus method cleaner.