### PR TITLE
libinputactions/touchpad: never block 1- and 2-finger hold gestures

### DIFF
--- a/src/libinputactions/handlers/TouchpadTriggerHandler.h
+++ b/src/libinputactions/handlers/TouchpadTriggerHandler.h
@@ -54,6 +54,7 @@ private:
 
     bool m_usesLibevdevBackend{};
     std::set<uint32_t> m_blockedButtons;
+    bool m_gestureBeginBlocked{};
 
     uint32_t m_clickTimeout = 200;
     QTimer m_clickTimeoutTimer;

--- a/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
+++ b/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
@@ -62,14 +62,16 @@ void TestTouchpadTriggerHandler::click_withLibinputButton()
     QCOMPARE(m_endingTriggersSpy->at(0).at(0).value<TriggerTypes>(), TriggerType::Click);
 }
 
-void TestTouchpadTriggerHandler::press1_notDelayed()
+void TestTouchpadTriggerHandler::press1_notDelayedOrBlocked()
 {
     m_handler->addTrigger(std::make_unique<Trigger>(TriggerType::Press));
 
-    m_handler->handleEvent(TouchpadGestureLifecyclePhaseEvent(m_touchpad.get(), TouchpadGestureLifecyclePhase::Begin, TriggerType::Press));
+    QCOMPARE(m_handler->handleEvent(TouchpadGestureLifecyclePhaseEvent(m_touchpad.get(), TouchpadGestureLifecyclePhase::Begin, TriggerType::Press, 1)), false);
 
     QCOMPARE(m_activatingTriggersSpy->count(), 1);
     QCOMPARE(m_activatingTriggersSpy->at(0).at(0).value<TriggerTypes>(), TriggerType::Press);
+
+    QCOMPARE(m_handler->handleEvent(TouchpadGestureLifecyclePhaseEvent(m_touchpad.get(), TouchpadGestureLifecyclePhase::End, TriggerType::Press)), false);
 }
 
 void TestTouchpadTriggerHandler::press1_hasClickTrigger_delayed()
@@ -118,6 +120,26 @@ void TestTouchpadTriggerHandler::press1_clickedDuringPress_pressCancelledAndClic
     QCOMPARE(m_endingTriggersSpy->count(), 0);
     QCOMPARE(m_activatingTriggersSpy->count(), 2);
     QCOMPARE(m_activatingTriggersSpy->at(1).at(0).value<TriggerTypes>(), TriggerType::Click);
+}
+
+void TestTouchpadTriggerHandler::press2_notDelayedOrBlocked()
+{
+    m_handler->addTrigger(std::make_unique<Trigger>(TriggerType::Press));
+
+    QCOMPARE(m_handler->handleEvent(TouchpadGestureLifecyclePhaseEvent(m_touchpad.get(), TouchpadGestureLifecyclePhase::Begin, TriggerType::Press, 2)), false);
+
+    QCOMPARE(m_activatingTriggersSpy->count(), 1);
+    QCOMPARE(m_activatingTriggersSpy->at(0).at(0).value<TriggerTypes>(), TriggerType::Press);
+
+    QCOMPARE(m_handler->handleEvent(TouchpadGestureLifecyclePhaseEvent(m_touchpad.get(), TouchpadGestureLifecyclePhase::End, TriggerType::Press)), false);
+}
+
+void TestTouchpadTriggerHandler::press3_blocked()
+{
+    m_handler->addTrigger(std::make_unique<Trigger>(TriggerType::Press));
+
+    QCOMPARE(m_handler->handleEvent(TouchpadGestureLifecyclePhaseEvent(m_touchpad.get(), TouchpadGestureLifecyclePhase::Begin, TriggerType::Press, 3)), true);
+    QCOMPARE(m_handler->handleEvent(TouchpadGestureLifecyclePhaseEvent(m_touchpad.get(), TouchpadGestureLifecyclePhase::End, TriggerType::Press)), true);
 }
 
 void TestTouchpadTriggerHandler::swipe2()

--- a/tests/libinputactions/handlers/TestTouchpadTriggerHandler.h
+++ b/tests/libinputactions/handlers/TestTouchpadTriggerHandler.h
@@ -16,10 +16,12 @@ private slots:
     void click_withLibinputButton_data();
     void click_withLibinputButton();
 
-    void press1_notDelayed();
+    void press1_notDelayedOrBlocked();
     void press1_hasClickTrigger_delayed();
     void press1_hasTapTrigger_delayed();
     void press1_clickedDuringPress_pressCancelledAndClickActivated();
+    void press2_notDelayedOrBlocked();
+    void press3_blocked();
 
     void swipe2();
 


### PR DESCRIPTION
1- and 2-finger hold gestures have almost no delay (so no compositor or application will have actions for them) and are used to stop kinetic scrolling, there's no reason to block them.