### PR TITLE
libinputactions/touchpad: fix finger variables during tap gesture activation

### DIFF
--- a/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.h
+++ b/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.h
@@ -55,6 +55,8 @@ protected:
 
     void reset() override;
 
+    static void updateVariables(const InputDevice *device);
+
     enum State
     {
         TouchpadButtonDown,
@@ -88,7 +90,14 @@ protected:
          */
         MotionTrigger,
 
-        TapBegin
+        /**
+         * A tap gesture had been recognized and is being handled by InputActions.
+         */
+        TapBegin,
+        /**
+         * A tap gesture had been recognized and will be handled on libinput's pointer button event.
+         */
+        LibinputTapBegin
     } m_state
         = State::None;
 
@@ -98,7 +107,6 @@ private:
     void handleTouchUpEvent(const TouchEvent &event);
 
     bool canTap();
-    static void updateVariables(const InputDevice *device);
 
     TouchPoint m_firstTouchPoint;
 

--- a/src/libinputactions/handlers/TouchpadTriggerHandler.cpp
+++ b/src/libinputactions/handlers/TouchpadTriggerHandler.cpp
@@ -82,6 +82,7 @@ bool TouchpadTriggerHandler::handleEvent(const PointerButtonEvent &event)
 {
     bool block{};
     switch (m_state) {
+        case State::LibinputTapBegin:
         case State::TouchIdle:
             if (event.state() && event.sender()->validTouchPoints().size() <= 3) {
                 uint8_t fingers;
@@ -98,9 +99,10 @@ bool TouchpadTriggerHandler::handleEvent(const PointerButtonEvent &event)
                 if (activateTriggers(TriggerType::Tap)) {
                     updateTriggers(TriggerType::Tap);
                     endTriggers(TriggerType::Tap);
-                    m_state = State::None;
                     block = true;
                 }
+                updateVariables(event.sender());
+                m_state = State::None;
             }
             break;
         case State::TouchpadButtonDownClickTrigger:

--- a/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
+++ b/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
@@ -225,6 +225,36 @@ void TestTouchpadTriggerHandler::tap1_tappedAgainBeforeLibinputButtonReleased()
     QCOMPARE(m_endingTriggersSpy->at(1).at(0).value<TriggerTypes>(), TriggerType::Tap);
 }
 
+void TestTouchpadTriggerHandler::tap2_variablesSetDuringActivation()
+{
+    m_handler->addTrigger(std::make_unique<Trigger>(TriggerType::Tap));
+
+    const QPointF first(0.1, 0.1);
+    const QPointF second(0.2, 0.2);
+    addPoint(first);
+    addPoint(second);
+
+    const auto finger1Position = g_variableManager->getVariable<QPointF>("finger_1_position_percentage");
+    const auto finger2Position = g_variableManager->getVariable<QPointF>("finger_2_position_percentage");
+    QCOMPARE(finger1Position->get(), first);
+    QCOMPARE(finger2Position->get(), second);
+
+    m_handler->handleEvent(TouchChangedEvent(m_touchpad.get(), m_touchpad->m_touchPoints[0], {}));
+    removePoints(1);
+    QCOMPARE(finger1Position->get(), first);
+    QCOMPARE(finger2Position->get(), second);
+
+    m_handler->handleEvent(TouchChangedEvent(m_touchpad.get(), m_touchpad->m_touchPoints[0], {}));
+    removePoints(1);
+    QCOMPARE(finger1Position->get(), first);
+    QCOMPARE(finger2Position->get(), second);
+
+    m_handler->handleEvent(PointerButtonEvent(m_touchpad.get(), Qt::MouseButton::LeftButton, BTN_LEFT, true));
+    m_handler->handleEvent(PointerButtonEvent(m_touchpad.get(), Qt::MouseButton::LeftButton, BTN_LEFT, false));
+    QVERIFY(!finger1Position->get().has_value());
+    QVERIFY(!finger2Position->get().has_value());
+}
+
 void TestTouchpadTriggerHandler::tap4()
 {
     m_handler->addTrigger(std::make_unique<Trigger>(TriggerType::Tap));

--- a/tests/libinputactions/handlers/TestTouchpadTriggerHandler.h
+++ b/tests/libinputactions/handlers/TestTouchpadTriggerHandler.h
@@ -28,6 +28,7 @@ private slots:
 
     void tap1();
     void tap1_tappedAgainBeforeLibinputButtonReleased();
+    void tap2_variablesSetDuringActivation();
     void tap4();
     void tap4_moved();
     void tap4_slow();


### PR DESCRIPTION
Fixes an issue where tap gestures with conditions using ``finger_`` variables would not activate.