### PR TITLE
libinputactions/handlers/motion: require >=2 deltas before determining direction

### DIFF
--- a/src/libinputactions/handlers/MotionTriggerHandler.h
+++ b/src/libinputactions/handlers/MotionTriggerHandler.h
@@ -88,6 +88,7 @@ private slots:
 private:
     Axis m_currentSwipeAxis = Axis::None;
     QPointF m_currentSwipeDelta;
+    uint32_t m_currentSwipeDeltaCount{};
 
     bool m_isDeterminingSpeed = false;
     uint8_t m_sampledInputEvents = 0;


### PR DESCRIPTION
One is not enough to accurately determine the direction, especially when it comes to mouse gestures.