### PR TITLE
libinputactions/pointer: implement hover gesture

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(libinputactions_SRCS
     libinputactions/handlers/MotionTriggerHandler.cpp
     libinputactions/handlers/MouseTriggerHandler.cpp
     libinputactions/handlers/MultiTouchMotionTriggerHandler.cpp
+    libinputactions/handlers/PointerTriggerHandler.cpp
     libinputactions/handlers/TouchpadTriggerHandler.cpp
     libinputactions/handlers/TriggerHandler.cpp
     libinputactions/input/backends/InputBackend.cpp
@@ -40,6 +41,7 @@ set(libinputactions_SRCS
     libinputactions/interfaces/Window.h
     libinputactions/interfaces/WindowProvider.cpp
     libinputactions/triggers/DirectionalMotionTrigger.cpp
+    libinputactions/triggers/HoverTrigger.cpp
     libinputactions/triggers/KeyboardShortcutTrigger.cpp
     libinputactions/triggers/MotionTrigger.cpp
     libinputactions/triggers/PressTrigger.cpp

--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -33,10 +33,12 @@
 #include <libinputactions/conditions/VariableCondition.h>
 #include <libinputactions/handlers/KeyboardTriggerHandler.h>
 #include <libinputactions/handlers/MouseTriggerHandler.h>
+#include <libinputactions/handlers/PointerTriggerHandler.h>
 #include <libinputactions/handlers/TouchpadTriggerHandler.h>
 #include <libinputactions/input/InputEventHandler.h>
 #include <libinputactions/input/Keyboard.h>
 #include <libinputactions/interfaces/CursorShapeProvider.h>
+#include <libinputactions/triggers/HoverTrigger.h>
 #include <libinputactions/triggers/KeyboardShortcutTrigger.h>
 #include <libinputactions/triggers/PressTrigger.h>
 #include <libinputactions/triggers/StrokeTrigger.h>
@@ -828,6 +830,11 @@ struct convert<std::vector<std::unique_ptr<InputEventHandler>>>
                 handlers.push_back(std::make_unique<InputEventHandler>(touchpadHandler.as<std::unique_ptr<TouchpadTriggerHandler>>()));
             }
         }
+        if (const auto &pointerNode = node["pointer"]) {
+            for (const auto &pointerHandler : asSequence(pointerNode)) {
+                handlers.push_back(std::make_unique<InputEventHandler>(pointerHandler.as<std::unique_ptr<PointerTriggerHandler>>()));
+            }
+        }
         return true;
     }
 };
@@ -902,6 +909,8 @@ struct convert<std::unique_ptr<Trigger>>
             auto pressTrigger = new PressTrigger;
             loadMember(pressTrigger->m_instant, node["instant"]);
             trigger.reset(pressTrigger);
+        } else if (type == "hover") {
+            trigger = std::make_unique<HoverTrigger>();
         } else if (type == "pinch") {
             trigger = std::make_unique<DirectionalMotionTrigger>(TriggerType::Pinch, static_cast<TriggerDirection>(node["direction"].as<PinchDirection>()));
         } else if (type == "rotate") {
@@ -1124,6 +1133,17 @@ struct convert<std::unique_ptr<MouseTriggerHandler>>
         loadMember(mouseTriggerHandler->m_pressTimeout, node["press_timeout"]);
         loadMember(mouseTriggerHandler->m_unblockButtonsOnTimeout, node["unblock_buttons_on_timeout"]);
 
+        return true;
+    }
+};
+
+template<>
+struct convert<std::unique_ptr<PointerTriggerHandler>>
+{
+    static bool decode(const Node &node, std::unique_ptr<PointerTriggerHandler> &handler)
+    {
+        handler = std::make_unique<PointerTriggerHandler>();
+        decodeTriggerHandler(node, handler.get());
         return true;
     }
 };

--- a/src/libinputactions/globals.h
+++ b/src/libinputactions/globals.h
@@ -49,6 +49,7 @@ enum class TriggerType : uint32_t
     Wheel = 1u << 6,
     KeyboardShortcut = 1u << 7,
     Tap = 1u << 8,
+    Hover = 1u << 9,
 
     PinchRotate = Pinch | Rotate,
     StrokeSwipe = Stroke | Swipe,

--- a/src/libinputactions/handlers/PointerTriggerHandler.cpp
+++ b/src/libinputactions/handlers/PointerTriggerHandler.cpp
@@ -1,0 +1,38 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "PointerTriggerHandler.h"
+
+namespace libinputactions
+{
+
+bool PointerTriggerHandler::handleEvent(const InputEvent &event)
+{
+    switch (event.type()) {
+        case InputEventType::PointerMotion:
+            if (hasActiveTriggers(TriggerType::Hover)) {
+                updateTriggers(TriggerType::Hover);
+            } else {
+                activateTriggers(TriggerType::Hover);
+            }
+            break;
+    }
+    return false;
+}
+
+}

--- a/src/libinputactions/handlers/PointerTriggerHandler.h
+++ b/src/libinputactions/handlers/PointerTriggerHandler.h
@@ -1,0 +1,35 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <chrono>
+#include "TriggerHandler.h"
+
+namespace libinputactions
+{
+
+class PointerTriggerHandler : public TriggerHandler
+{
+public:
+    PointerTriggerHandler() = default;
+
+    bool handleEvent(const InputEvent &event) override;
+};
+
+}

--- a/src/libinputactions/handlers/TriggerHandler.cpp
+++ b/src/libinputactions/handlers/TriggerHandler.cpp
@@ -24,7 +24,7 @@ Q_LOGGING_CATEGORY(INPUTACTIONS_HANDLER_TRIGGER, "inputactions.handler.trigger",
 namespace libinputactions
 {
 
-static const std::vector<TriggerType> TIMED_TRIGGERS = {TriggerType::Click, TriggerType::KeyboardShortcut, TriggerType::Press};
+static const std::vector<TriggerType> TIMED_TRIGGERS = {TriggerType::Click, TriggerType::KeyboardShortcut, TriggerType::Hover, TriggerType::Press};
 
 TriggerHandler::TriggerHandler()
 {

--- a/src/libinputactions/triggers/HoverTrigger.cpp
+++ b/src/libinputactions/triggers/HoverTrigger.cpp
@@ -1,0 +1,34 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "HoverTrigger.h"
+
+namespace libinputactions
+{
+
+HoverTrigger::HoverTrigger()
+    : Trigger(TriggerType::Hover)
+{
+}
+
+bool HoverTrigger::canUpdate(const TriggerUpdateEvent &event) const
+{
+    return Trigger::canUpdate(event) && (!m_activationCondition || m_activationCondition->satisfied());
+}
+
+}

--- a/src/libinputactions/triggers/HoverTrigger.h
+++ b/src/libinputactions/triggers/HoverTrigger.h
@@ -1,0 +1,34 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "Trigger.h"
+
+namespace libinputactions
+{
+
+class HoverTrigger : public Trigger
+{
+public:
+    HoverTrigger();
+
+    bool canUpdate(const TriggerUpdateEvent &event) const override;
+};
+
+}


### PR DESCRIPTION
Activates when the pointer enters an area that satisfies the gesture's conditions, ends when it leaves that area or the area no longer satisfies conditions.

Type is ``hover``, defined in the ``pointer.gestures`` root node.

closes #189