### PR TITLE
libinputactions/keyboard: allow single, non-modifier key shortcuts

### DIFF
--- a/src/libinputactions/handlers/KeyboardTriggerHandler.cpp
+++ b/src/libinputactions/handlers/KeyboardTriggerHandler.cpp
@@ -41,10 +41,6 @@ bool KeyboardTriggerHandler::handleEvent(const KeyboardKeyEvent &event)
         if (m_keys.size() == 1) {
             m_firstKey = event.nativeKey();
         }
-        if (!MODIFIERS.contains(m_firstKey)) {
-            m_block = false;
-            return false;
-        }
 
         m_block = activateTriggers(TriggerType::KeyboardShortcut);
         return m_block && !isModifier;
@@ -59,6 +55,7 @@ std::unique_ptr<TriggerActivationEvent> KeyboardTriggerHandler::createActivation
 {
     auto event = TriggerHandler::createActivationEvent();
     event->keyboardKeys = {m_keys.begin(), m_keys.end()};
+    event->keyboardFirstKey = m_firstKey;
     return event;
 }
 

--- a/src/libinputactions/triggers/KeyboardShortcutTrigger.cpp
+++ b/src/libinputactions/triggers/KeyboardShortcutTrigger.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "KeyboardShortcutTrigger.h"
+#include <libinputactions/input/Keyboard.h>
 
 namespace libinputactions
 {
@@ -29,7 +30,15 @@ KeyboardShortcutTrigger::KeyboardShortcutTrigger(KeyboardShortcut shortcut)
 
 bool KeyboardShortcutTrigger::canActivate(const TriggerActivationEvent &event) const
 {
-    return Trigger::canActivate(event) && (m_shortcut.keys == event.keyboardKeys);
+    if (!Trigger::canActivate(event) || m_shortcut.keys != event.keyboardKeys) {
+        return false;
+    }
+
+    // If the shortcut contains a modifier key, the first key must be a modifier.
+    const auto hasModifier = std::ranges::any_of(m_shortcut.keys, [](auto key) {
+                                 return MODIFIERS.contains(key);
+                             });
+    return !hasModifier || MODIFIERS.contains(event.keyboardFirstKey);
 }
 
 }

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -37,6 +37,7 @@ class TriggerActivationEvent
 {
 public:
     std::set<uint32_t> keyboardKeys;
+    uint32_t keyboardFirstKey{};
     std::optional<std::vector<Qt::MouseButton>> mouseButtons;
 };
 class TriggerUpdateEvent

--- a/tests/libinputactions/handlers/TestKeyboardTriggerHandler.h
+++ b/tests/libinputactions/handlers/TestKeyboardTriggerHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QTest>
+#include <libinputactions/input/InputDevice.h>
 
 namespace libinputactions
 {
@@ -10,7 +11,15 @@ class TestKeyboardTriggerHandler : public QObject
     Q_OBJECT
 
 private slots:
-    void handleEvent_keyboardKey();
+    void init();
+
+    void shortcut_oneModifierKeyShortcut_triggerActivatedEndedAndEventsNotBlocked();
+    void shortcut_oneNonModifierKeyShortcut_triggerActivatedEndedAndEventsBlocked();
+    void shortcut_twoKeysWrongOrder_triggerNotActivatedAndEventsNotBlocked();
+    void shortcut_twoKeysCorrectOrder_triggerActivatedAndNormalKeyBlockedAndModifierKeyNotBlocked();
+
+private:
+    std::unique_ptr<InputDevice> m_device;
 };
 
 }


### PR DESCRIPTION
https://github.com/iberianpig/fusuma-plugin-thumbsense allows for remapping individual keys to other keys and mouse buttons when a finger is present on the touchpad, so there is a use for them.