### PR TITLE
libinputactions: add pointer locking for mouse motion triggers

### DIFF
--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -937,6 +937,7 @@ struct convert<std::unique_ptr<Trigger>>
         loadMember(trigger->m_setLastTrigger, node["set_last_trigger"]);
         loadMember(trigger->m_threshold, node["threshold"]);
         if (auto *motionTrigger = dynamic_cast<MotionTrigger *>(trigger.get())) {
+            loadMember(motionTrigger->m_lockPointer, node["lock_pointer"]);
             loadMember(motionTrigger->m_speed, node["speed"]);
         }
 

--- a/src/libinputactions/input/backends/LibinputCompositorInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibinputCompositorInputBackend.cpp
@@ -86,8 +86,7 @@ bool LibinputCompositorInputBackend::pointerMotion(InputDevice *sender, const QP
     }
 
     const auto isTouchpad = sender->type() == InputDeviceType::Touchpad;
-    // Don't block mouse motion for now, more changes are required
-    auto block = handleEvent(MotionEvent(sender, InputEventType::PointerMotion, isTouchpad ? deltaUnaccelerated : delta)) && isTouchpad;
+    auto block = handleEvent(MotionEvent(sender, InputEventType::PointerMotion, isTouchpad ? deltaUnaccelerated : delta));
     if (block && m_previousPointerPosition) {
         g_pointerPositionSetter->setGlobalPointerPosition(m_previousPointerPosition.value());
     }

--- a/src/libinputactions/triggers/MotionTrigger.h
+++ b/src/libinputactions/triggers/MotionTrigger.h
@@ -51,6 +51,10 @@ public:
 
     bool hasSpeed() const;
 
+    /**
+     * Lock the pointer while this trigger is active. Only applies to mouse triggers.
+     */
+    bool m_lockPointer{};
     TriggerSpeed m_speed = TriggerSpeed::Any;
 
 protected:


### PR DESCRIPTION
New property for mouse swipe and stroke triggers:
| Property | Type | Description | Default |
|-|-|-|-|
| lock_pointer | *bool* | Lock the pointer's position while the trigger is active.<br>Currently not supported on Hyprland. | ``false`` |

It's not perfect, the pointer may be able to move a few pixels in the short period of time where triggers have not been activated yet.