### PR TITLE
libinputactions: reactivate swipe triggers on axis change

### DIFF
--- a/src/libinputactions/handlers/MotionTriggerHandler.h
+++ b/src/libinputactions/handlers/MotionTriggerHandler.h
@@ -88,7 +88,7 @@ private slots:
 private:
     Axis m_currentSwipeAxis = Axis::None;
     QPointF m_currentSwipeDelta;
-    uint32_t m_currentSwipeDeltaCount{};
+    QPointF m_averageSwipeDelta;
 
     bool m_isDeterminingSpeed = false;
     uint8_t m_sampledInputEvents = 0;
@@ -96,7 +96,7 @@ private:
     std::optional<TriggerSpeed> m_speed;
     std::vector<TriggerSpeedThreshold> m_speedThresholds;
 
-    std::vector<QPointF> m_stroke;
+    std::vector<QPointF> m_deltas;
 };
 
 }


### PR DESCRIPTION
If the swipe axis changes and as a result of that all triggers are cancelled, swipe triggers will be reactivated, making it possible to create chained swipe triggers (e.g. left then up) that do not require lifting fingers.

closes #221 