### PR TITLE
libinputactions: add on: tick actions

### DIFF
--- a/src/libinputactions/actions/TriggerAction.h
+++ b/src/libinputactions/actions/TriggerAction.h
@@ -41,6 +41,7 @@ enum class On
     Cancel,
     End,
     EndCancel,
+    Tick,
     Update
 };
 
@@ -114,6 +115,11 @@ public:
      * Called by the trigger.
      * @internal
      */
+    void triggerTick(qreal delta);
+    /**
+     * Called by the trigger.
+     * @internal
+     */
     void triggerEnded();
     /**
      * Called by the trigger.
@@ -149,6 +155,8 @@ public:
     std::optional<Range<qreal>> m_threshold;
 
 private:
+    void update(qreal delta);
+
     /**
      * Resets member variables that hold information about the performed input action.
      */

--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -1200,10 +1200,11 @@ struct convert<std::unique_ptr<TouchpadTriggerHandler>>
 ENUM_DECODER(On, "action event (on)",
              (std::unordered_map<QString, On>{
                  {"begin", On::Begin},
-                 {"update", On::Update},
                  {"cancel", On::Cancel},
                  {"end", On::End},
                  {"end_cancel", On::EndCancel},
+                 {"tick", On::Tick},
+                 {"update", On::Update},
              }))
 ENUM_DECODER(CursorShape, "cursor shape", CURSOR_SHAPES)
 ENUM_DECODER(Qt::MouseButton, "mouse button",

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <QLoggingCategory>
+#include <QTimer>
 #include <QString>
 #include <libinputactions/actions/TriggerAction.h>
 #include <libinputactions/conditions/Condition.h>
@@ -178,12 +179,16 @@ protected:
 
     virtual void updateActions(const TriggerUpdateEvent &event);
 
+private slots:
+    void onTick();
+
 private:
     void reset();
 
     TriggerType m_type{0};
     std::vector<std::unique_ptr<TriggerAction>> m_actions;
     bool m_started = false;
+    QTimer m_tickTimer;
 
     bool m_withinThreshold = false;
     qreal m_absoluteAccumulatedDelta = 0;


### PR DESCRIPTION
Now it's possible to create time-based actions in motion triggers, like these ones that continue to move the pointer when a finger is near the touchpad edge:
```yaml
touchpad:
  gestures:
    - type: swipe
      fingers: 3
      direction: any

      actions:
        - on: begin
          input:
            - keyboard: [ +leftmeta ]
            - mouse: [ +left ]

        - on: update
          input:
            - mouse: [ move_by_delta ]

        - on: end_cancel
          input:
            - keyboard: [ -leftmeta ]
            - mouse: [ -left ]

        - on: tick
          conditions:
            any:
              - $finger_1_position_percentage_x >= 0.9
              - $finger_2_position_percentage_x >= 0.9
              - $finger_3_position_percentage_x >= 0.9

          input:
            - mouse: [ move_by 2 0 ]

        - on: tick
          conditions:
            any:
              - $finger_1_position_percentage_y >= 0.9
              - $finger_2_position_percentage_y >= 0.9
              - $finger_3_position_percentage_y >= 0.9

          input:
            - mouse: [ move_by 0 2 ]

        - on: tick
          conditions:
            any:
              - $finger_1_position_percentage_x <= 0.1
              - $finger_2_position_percentage_x <= 0.1
              - $finger_3_position_percentage_x <= 0.1

          input:
            - mouse: [ move_by -2 0 ]

        - on: tick
          conditions:
            any:
              - $finger_1_position_percentage_y <= 0.1
              - $finger_2_position_percentage_y <= 0.1
              - $finger_3_position_percentage_y <= 0.1

          input:
            - mouse: [ move_by 0 -2 ]
```

Changed property of [Action](https://wiki.inputactions.org/main/actions/index.html):
| Property | Type | Description | Default |
|-|-|-|-|
| on | *enum(begin, cancel, end, end_cancel, tick, update)* | At which point of the trigger's lifecycle the action should be executed.<br><br>``on: tick`` actions are executed every 5 ms with a delta of 5 (same as time-based triggers) and can be used to create time-based actions in non-time-based triggers. | ``end`` |

closes #212 