### PR TITLE
libinputactions/actions/input: add mouse wheel

### DIFF
--- a/src/kwin/interfaces/KWinInputEmitter.cpp
+++ b/src/kwin/interfaces/KWinInputEmitter.cpp
@@ -94,6 +94,19 @@ void KWinInputEmitter::keyboardText(const QString &text)
     }
 }
 
+void KWinInputEmitter::mouseAxis(const QPointF &delta)
+{
+    libinputactions::g_inputBackend->setIgnoreEvents(true);
+    if (delta.x()) {
+        Q_EMIT m_device->pointerAxisChanged(KWin::PointerAxis::Horizontal, delta.x(), delta.x(), KWin::PointerAxisSource::Wheel, false, timestamp(), m_device.get());
+    }
+    if (delta.y()) {
+        Q_EMIT m_device->pointerAxisChanged(KWin::PointerAxis::Vertical, delta.y(), delta.y(), KWin::PointerAxisSource::Wheel, false, timestamp(), m_device.get());
+    }
+    Q_EMIT m_device->pointerFrame(m_device.get());
+    libinputactions::g_inputBackend->setIgnoreEvents(false);
+}
+
 void KWinInputEmitter::mouseButton(uint32_t button, bool state)
 {
     libinputactions::g_inputBackend->setIgnoreEvents(true);

--- a/src/kwin/interfaces/KWinInputEmitter.h
+++ b/src/kwin/interfaces/KWinInputEmitter.h
@@ -53,6 +53,7 @@ public:
     void keyboardKey(uint32_t key, bool state) override;
     void keyboardText(const QString &text) override;
 
+    void mouseAxis(const QPointF &delta) override;
     void mouseButton(uint32_t button, bool state) override;
     void mouseMoveRelative(const QPointF &pos) override;
 

--- a/src/libinputactions/actions/InputAction.cpp
+++ b/src/libinputactions/actions/InputAction.cpp
@@ -46,6 +46,8 @@ void InputAction::executeImpl()
                     g_inputEmitter->mouseButton(item.mousePress, true);
                 } else if (item.mouseRelease) {
                     g_inputEmitter->mouseButton(item.mouseRelease, false);
+                } else if (!item.mouseAxis.isNull()) {
+                    g_inputEmitter->mouseAxis(item.mouseAxis);
                 } else if (!item.mouseMoveAbsolute.isNull()) {
                     g_pointerPositionSetter->setGlobalPointerPosition(item.mouseMoveAbsolute);
                 } else if (!item.mouseMoveRelative.isNull()) {

--- a/src/libinputactions/actions/InputAction.h
+++ b/src/libinputactions/actions/InputAction.h
@@ -41,6 +41,7 @@ public:
         uint32_t mousePress{};
         uint32_t mouseRelease{};
 
+        QPointF mouseAxis;
         QPointF mouseMoveAbsolute;
         QPointF mouseMoveRelative;
         bool mouseMoveRelativeByDelta{};

--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -1373,6 +1373,10 @@ struct convert<std::vector<InputAction::Item>>
                         value.push_back({
                             .mouseMoveAbsolute = parseMouseInputActionPoint(node, arguments),
                         });
+                    } else if (action.startsWith("WHEEL")) {
+                        value.push_back({
+                            .mouseAxis = parseMouseInputActionPoint(node, arguments),
+                        });
                     } else {
                         std::vector<uint32_t> buttons;
                         for (const auto &buttonRaw : action.split("+")) {

--- a/src/libinputactions/interfaces/InputEmitter.h
+++ b/src/libinputactions/interfaces/InputEmitter.h
@@ -30,23 +30,27 @@ public:
     InputEmitter() = default;
     virtual ~InputEmitter() = default;
 
-    virtual void keyboardClearModifiers() {};
+    virtual void keyboardClearModifiers() {}
     /**
      * @param key <linux/input-event-codes.h>
      * @param state True - press, false - release
      */
-    virtual void keyboardKey(uint32_t key, bool state) {};
-    virtual void keyboardText(const QString &text) {};
+    virtual void keyboardKey(uint32_t key, bool state) {}
+    virtual void keyboardText(const QString &text) {}
 
+    /**
+     * @param delta Both X and Y values may be specified.
+     */
+    virtual void mouseAxis(const QPointF &delta) {}
     /**
      * @param button <linux/input-event-codes.h>
      * @param state True - press, false - release
      */
-    virtual void mouseButton(uint32_t button, bool state) {};
-    virtual void mouseMoveRelative(const QPointF &pos) {};
+    virtual void mouseButton(uint32_t button, bool state) {}
+    virtual void mouseMoveRelative(const QPointF &pos) {}
 
-    virtual void touchpadPinchBegin(uint8_t fingers) {};
-    virtual void touchpadSwipeBegin(uint8_t fingers) {};
+    virtual void touchpadPinchBegin(uint8_t fingers) {}
+    virtual void touchpadSwipeBegin(uint8_t fingers) {}
 };
 
 inline std::shared_ptr<InputEmitter> g_inputEmitter;


### PR DESCRIPTION
Couldn't get it to work on Hyprland so KWin only for now.

There will be no actions for moving the wheel by the delta or the distance from the origin (both of which would be useful for autoscrolling gestures), that will be achievable with scripting, which will be added soon.

## [MouseAction](https://wiki.inputactions.org/main/actions/input.html#mouseaction)
| Action | Description |
|-|-|
| ``wheel [x] [y]`` | Move the wheel by (*x*, *y*). 

```yaml
input:
  - mouse: [ wheel 0 10 ]
```

closes #158