### PR TITLE
libinputactions/backends/libinput: sync touchpad click state on (0,0) axis events

### DIFF
--- a/src/libinputactions/input/backends/LibinputCompositorInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibinputCompositorInputBackend.cpp
@@ -54,6 +54,9 @@ bool LibinputCompositorInputBackend::pointerAxis(InputDevice *sender, const QPoi
         return true;
     }
 
+    if (delta.isNull() && sender->type() == InputDeviceType::Touchpad) {
+        LibevdevComplementaryInputBackend::poll(); // Update clicked state, clicking cancels scrolling and generates a (0,0) event
+    }
     return handleEvent(MotionEvent(sender, InputEventType::PointerScroll, delta));
 }
 


### PR DESCRIPTION
Fixes an issue where 2-finger touchpad click gestures would not work if scrolling was performed immediately prior.