### PR TITLE
libinputactions: always perform conflict resolution if active trigger count > 1

### DIFF
--- a/src/libinputactions/handlers/TriggerHandler.cpp
+++ b/src/libinputactions/handlers/TriggerHandler.cpp
@@ -126,13 +126,12 @@ bool TriggerHandler::updateTriggers(const std::map<TriggerType, const TriggerUpd
         hasTriggers = true;
         trigger->update(*event);
 
-        if (!m_conflictsResolved && m_activeTriggers.size() > 1) {
+        if (m_activeTriggers.size() > 1) {
             qCDebug(INPUTACTIONS_TRIGGER, "Cancelling conflicting triggers");
-            m_conflictsResolved = true;
             if (trigger->overridesOtherTriggersOnUpdate()) {
                 cancelTriggers(trigger);
                 break;
-            } else if (types & TriggerType::Stroke) { // TODO This should be in MotionTriggerHandler
+            } else if (types & TriggerType::Stroke && hasActiveTriggers(TriggerType::Swipe)) { // TODO This should be in MotionTriggerHandler
                 cancelTriggers(TriggerType::Swipe);
                 break;
             }
@@ -283,7 +282,6 @@ std::unique_ptr<TriggerActivationEvent> TriggerHandler::createActivationEvent() 
 
 void TriggerHandler::reset()
 {
-    m_conflictsResolved = false;
 }
 
 }

--- a/src/libinputactions/handlers/TriggerHandler.h
+++ b/src/libinputactions/handlers/TriggerHandler.h
@@ -124,11 +124,6 @@ signals:
 
 private:
     /**
-     * Whether conflicting triggers have been cancelled since activation.
-     */
-    bool m_conflictsResolved = false;
-
-    /**
      * Updates timed triggers. Stops itself if no triggers are active.
      */
     QTimer m_timedTriggerUpdateTimer;


### PR DESCRIPTION
Fixes an issue where triggers with minimum thresholds do not override other triggers once it is reached and an action is executed.