### PR TITLE
kwin: install input event filter before DragAndDrop

### DIFF
--- a/src/kwin/input/KWinInputBackend.cpp
+++ b/src/kwin/input/KWinInputBackend.cpp
@@ -25,7 +25,7 @@
 using namespace libinputactions;
 
 KWinInputBackend::KWinInputBackend()
-    : InputEventFilter(KWin::InputFilterOrder::TabBox)
+    : InputEventFilter(KWin::InputFilterOrder::ScreenEdge)
 {
     auto *input = KWin::input();
     connect(input, &KWin::InputRedirection::deviceAdded, this, &KWinInputBackend::kwinDeviceAdded);


### PR DESCRIPTION
Fixes triggers not working after a drag-and-drop.