### PR TITLE
ci: Add Zizmor workflow and apply recommendations

### DIFF
--- a/.github/workflows/arch-linux.yml
+++ b/.github/workflows/arch-linux.yml
@@ -10,16 +10,21 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   build_hyprland:
+    name: Build (Hyprland)
     runs-on: ubuntu-latest
     container:
-      image: archlinux:base-devel
+      image: archlinux:base-devel # zizmor: ignore[unpinned-images]
       options: --user root
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Refresh Packages
         run: pacman -Syu --noconfirm
@@ -28,20 +33,23 @@ jobs:
         run: pacman -S --needed --noconfirm base-devel git extra-cmake-modules qt6-tools hyprland yaml-cpp libevdev
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DINPUTACTIONS_BUILD_HYPRLAND=ON
+        run: cmake -B "${GITHUB_WORKSPACE}/build" -DINPUTACTIONS_BUILD_HYPRLAND=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build -j
+        run: cmake --build "${GITHUB_WORKSPACE}/build" -j
 
   build_kwin:
+    name: Build (KWin)
     runs-on: ubuntu-latest
     container:
-      image: archlinux:base-devel
+      image: archlinux:base-devel # zizmor: ignore[unpinned-images]
       options: --user root
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Refresh Packages
         run: pacman -Syu --noconfirm
@@ -50,7 +58,7 @@ jobs:
         run: pacman -S --needed --noconfirm base-devel git extra-cmake-modules qt6-tools kwin yaml-cpp libevdev
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DINPUTACTIONS_BUILD_KWIN=ON
+        run: cmake -B "${GITHUB_WORKSPACE}/build" -DINPUTACTIONS_BUILD_KWIN=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build -j
+        run: cmake --build "${GITHUB_WORKSPACE}/build" -j

--- a/.github/workflows/debian-experimental.yml
+++ b/.github/workflows/debian-experimental.yml
@@ -10,16 +10,21 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   build_kwin:
+    name: Build (KWin)
     runs-on: ubuntu-latest
     container:
-      image: debian:experimental
+      image: debian:experimental # zizmor: ignore[unpinned-images]
       options: --user root
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Refresh Packages
         run: apt-get update
@@ -31,7 +36,7 @@ jobs:
         run: apt-get install -y -f cmake g++ extra-cmake-modules qt6-tools-dev kwin-wayland kwin-dev libkf6configwidgets-dev gettext libkf6kcmutils-dev libyaml-cpp-dev libxkbcommon-dev pkg-config libevdev-dev
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DINPUTACTIONS_BUILD_KWIN=ON
+        run: cmake -B "${GITHUB_WORKSPACE}/build" -DINPUTACTIONS_BUILD_KWIN=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build -j
+        run: cmake --build "${GITHUB_WORKSPACE}/build" -j

--- a/.github/workflows/fedora-42.yml
+++ b/.github/workflows/fedora-42.yml
@@ -10,22 +10,27 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   build_kwin:
+    name: Build (KWin)
     runs-on: ubuntu-latest
     container:
-      image: fedora:42
+      image: fedora:42 # zizmor: ignore[unpinned-images]
       options: --user root
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Dependencies
         run: dnf -y install cmake extra-cmake-modules gcc-g++ qt6-qtbase-devel kwin-devel kf6-ki18n-devel kf6-kguiaddons-devel kf6-kcmutils-devel kf6-kconfigwidgets-devel qt6-qtbase kf6-kguiaddons kf6-ki18n wayland-devel yaml-cpp yaml-cpp-devel libepoxy-devel libevdev libevdev-devel libdrm-devel
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DINPUTACTIONS_BUILD_KWIN=ON
+        run: cmake -B "${GITHUB_WORKSPACE}/build" -DINPUTACTIONS_BUILD_KWIN=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build -j
+        run: cmake --build "${GITHUB_WORKSPACE}/build" -j

--- a/.github/workflows/neon-unstable.yml
+++ b/.github/workflows/neon-unstable.yml
@@ -10,16 +10,21 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   build_kwin:
+    name: Build (KWin)
     runs-on: ubuntu-latest
     container:
-      image: invent-registry.kde.org/neon/docker-images/plasma:unstable
+      image: invent-registry.kde.org/neon/docker-images/plasma:unstable # zizmor: ignore[unpinned-images]
       options: --user root
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Refresh Packages
         run: apt update
@@ -31,7 +36,7 @@ jobs:
         run: apt install -y cmake g++ extra-cmake-modules qt6-tools-dev kwin-wayland kwin-dev libkf6configwidgets-dev gettext libkf6kcmutils-dev libyaml-cpp-dev libxkbcommon-dev pkg-config libevdev-dev
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DINPUTACTIONS_BUILD_KWIN=ON
+        run: cmake -B "${GITHUB_WORKSPACE}/build" -DINPUTACTIONS_BUILD_KWIN=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build -j
+        run: cmake --build "${GITHUB_WORKSPACE}/build" -j

--- a/.github/workflows/nixos-plasma-6-3.yml
+++ b/.github/workflows/nixos-plasma-6-3.yml
@@ -10,20 +10,25 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   build_kwin:
+    name: Build (KWin)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@fd24c48048070c1be9acd18c9d369a83f0fe94d7 # v31.8.1
         with:
           nix_path: nixpkgs=channel:56e3ac24f80cecab5416f104f4289cb0f8eb84c0
 
       - name: Patch flake.nix
-        run: sed -i 's/nixos-unstable/56e3ac24f80cecab5416f104f4289cb0f8eb84c0/g' flake.nix
+        run: sed -i -e 's/nixos-unstable/56e3ac24f80cecab5416f104f4289cb0f8eb84c0/g' flake.nix
 
       - name: Update flake.lock
         run: nix flake update

--- a/.github/workflows/nixos-unstable.yml
+++ b/.github/workflows/nixos-unstable.yml
@@ -10,15 +10,20 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   build_hyprland:
+    name: Build (Hyprland)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@fd24c48048070c1be9acd18c9d369a83f0fe94d7 # v31.8.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -29,13 +34,16 @@ jobs:
         run: nix build -L .#inputactions-hyprland
 
   build_kwin:
+    name: Build (KWin)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v27
+        uses: cachix/install-nix-action@fd24c48048070c1be9acd18c9d369a83f0fe94d7 # v31.8.1
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.github/workflows/opensuse-tumbleweed.yml
+++ b/.github/workflows/opensuse-tumbleweed.yml
@@ -10,16 +10,21 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: {}
+
 jobs:
   build_kwin:
+    name: Build (KWin)
     runs-on: ubuntu-latest
     container:
-      image: opensuse/tumbleweed
+      image: opensuse/tumbleweed # zizmor: ignore[unpinned-images]
       options: --user root
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Refresh Packages
         run: zypper ref
@@ -28,7 +33,7 @@ jobs:
         run: zypper in -y cmake-full gcc-c++ kf6-extra-cmake-modules kf6-kguiaddons-devel kf6-kconfigwidgets-devel kf6-ki18n-devel kf6-kcmutils-devel "cmake(KF6I18n)" "cmake(KF6KCMUtils)" "cmake(KF6WindowSystem)" "cmake(Qt6Core)" "cmake(Qt6DBus)" "cmake(Qt6Quick)" "cmake(Qt6Widgets)" libepoxy-devel kwin6-devel yaml-cpp-devel libxkbcommon-devel libevdev-devel
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DINPUTACTIONS_BUILD_KWIN=ON
+        run: cmake -B "${GITHUB_WORKSPACE}/build" -DINPUTACTIONS_BUILD_KWIN=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build -j
+        run: cmake --build "${GITHUB_WORKSPACE}/build" -j

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,14 @@ name: Test
 
 on: [push]
 
+permissions: {}
+
 jobs:
   test:
+    name: Tests
     runs-on: ubuntu-latest
     container:
-      image: archlinux:base-devel
+      image: archlinux:base-devel # zizmor: ignore[unpinned-images]
       options: --user root
 
     steps:
@@ -17,13 +20,15 @@ jobs:
         run: pacman -S --needed --noconfirm base-devel git extra-cmake-modules qt6-tools kwin yaml-cpp gtest
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Configure CMake
-        run: cmake -B ${{github.workspace}}/build -DBUILD_KWIN_EFFECT=OFF -DBUILD_TESTS=ON
+        run: cmake -B "${GITHUB_WORKSPACE}/build" -DBUILD_KWIN_EFFECT=OFF -DBUILD_TESTS=ON
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build -j $(nproc)
+        run: cmake --build "${GITHUB_WORKSPACE}/build" -j $(nproc)
 
       - name: Run tests
-        run: ctest --test-dir ${{github.workspace}}/build --output-on-failure --verbose
+        run: ctest --test-dir "${GITHUB_WORKSPACE}/build" --output-on-failure --verbose

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # needed to create vulnerability alerts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
+        with:
+          persona: pedantic


### PR DESCRIPTION
[Zizmor's](https://docs.zizmor.sh/) security recommendations applied here include:

* Remove unnecessary permissions from workflows.
* Pin GitHub actions dependencies using commit hashes (and update them to the latest versions).
* Use `persist-credentials: false` for `actions/checkout`.
* Use environment variables in place of template expansion to prevent code injection.

Zizmor also warns about unpinned container image references, but I explicitly ignore that here, because (1) the purpose of those workflows is to test the build on the *latest* version of various systems, and (2) the workflows are permissionless and don't publish any artifacts, so the risk seems low even if one of those containers were compromised.