### PR TITLE
libinputactions: implement non-blocking triggers

### DIFF
--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -918,6 +918,7 @@ struct convert<std::unique_ptr<Trigger>>
             throw Exception(node.Mark(), "Invalid trigger type");
         }
 
+        loadMember(trigger->m_blockEvents, node["block_events"]);
         loadMember(trigger->m_clearModifiers, node["clear_modifiers"]);
         loadMember(trigger->m_endCondition, node["end_conditions"]);
         loadMember(trigger->m_id, node["id"]);

--- a/src/libinputactions/handlers/KeyboardTriggerHandler.cpp
+++ b/src/libinputactions/handlers/KeyboardTriggerHandler.cpp
@@ -43,7 +43,7 @@ bool KeyboardTriggerHandler::keyboardKey(const KeyboardKeyEvent &event)
             return false;
         }
 
-        m_block = activateTriggers(TriggerType::KeyboardShortcut);
+        m_block = activateTriggers(TriggerType::KeyboardShortcut).block;
         return m_block && !isModifier;
     }
 

--- a/src/libinputactions/handlers/MotionTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MotionTriggerHandler.cpp
@@ -129,12 +129,12 @@ bool MotionTriggerHandler::handleMotion(const QPointF &delta)
         events[TriggerType::Stroke] = &strokeEvent;
     }
 
-    const auto block = updateTriggers(events);
-    if (axisChanged && !block) {
+    const auto result = updateTriggers(events);
+    if (axisChanged && !result.success) {
         activateTriggers(TriggerType::Swipe);
         return handleMotion(delta);
     }
-    return block;
+    return result.block;
 }
 
 bool MotionTriggerHandler::determineSpeed(TriggerType type, qreal delta, TriggerSpeed &speed, TriggerDirection direction)

--- a/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MultiTouchMotionTriggerHandler.cpp
@@ -74,7 +74,7 @@ bool MultiTouchMotionTriggerHandler::touchUp(const TouchEvent &event)
 
             if (canTap()) {
                 if (m_state == State::TouchIdle) {
-                    setState(activateTriggers(TriggerType::Tap) ? State::TapBegin : State::Touch);
+                    setState(activateTriggers(TriggerType::Tap).success ? State::TapBegin : State::Touch);
                 }
                 if (m_state == State::TapBegin && event.sender()->validTouchPoints().empty()) {
                     updateTriggers(TriggerType::Tap);
@@ -159,10 +159,10 @@ bool MultiTouchMotionTriggerHandler::handlePinch(qreal scale, qreal angleDelta)
     event.m_delta = delta;
     event.m_direction = direction;
     event.m_speed = speed;
-    const auto hasGestures = updateTriggers(type, event);
+    const auto result = updateTriggers(type, event);
 
-    qCDebug(INPUTACTIONS_HANDLER_MULTITOUCH).nospace() << "Event processed (type: Pinch, hasGestures: " << hasGestures << ")";
-    return hasGestures;
+    qCDebug(INPUTACTIONS_HANDLER_MULTITOUCH).nospace() << "Event processed (type: Pinch, hasGestures: " << result.success << ")";
+    return result.block;
 }
 
 void MultiTouchMotionTriggerHandler::reset()

--- a/src/libinputactions/handlers/TriggerHandler.h
+++ b/src/libinputactions/handlers/TriggerHandler.h
@@ -26,6 +26,18 @@ Q_DECLARE_LOGGING_CATEGORY(INPUTACTIONS_HANDLER_TRIGGER)
 namespace libinputactions
 {
 
+struct TriggerManagementOperationResult
+{
+    /**
+     * Whether the operation was performed on at least one trigger.
+     */
+    bool success{};
+    /**
+     * Whether the event corresponding to the operation should be blocked, if possible.
+     */
+    bool block{};
+};
+
 /**
  * Base class of all handlers.
  */
@@ -46,38 +58,34 @@ protected:
 
     /**
      * Cancels all active triggers and activates triggers of the specified types eligible for activation.
-     * @return Whether any triggers have been activated.
      */
-    bool activateTriggers(TriggerTypes types, const TriggerActivationEvent &event);
+    TriggerManagementOperationResult activateTriggers(TriggerTypes types, const TriggerActivationEvent &event);
     /**
      * @see activateTriggers(const TriggerTypes &, const TriggerActivationEvent *)
      */
-    bool activateTriggers(TriggerTypes types);
+    TriggerManagementOperationResult activateTriggers(TriggerTypes types);
 
     /**
      * Updates triggers of multiple types in order as added to the handler.
-     * @return Whether there are any active triggers.
      */
-    bool updateTriggers(const std::map<TriggerType, const TriggerUpdateEvent *> &events);
+    TriggerManagementOperationResult updateTriggers(const std::map<TriggerType, const TriggerUpdateEvent *> &events);
     /**
      * Updates triggers of a single type.
      * @warning Do not use this to update multiple trigger types, as it will prevent conflict resolution from working
      * correctly.
      * @see updateTriggers(const std::map<TriggerType, const TriggerUpdateEvent *> &events)
      */
-    bool updateTriggers(TriggerType type, const TriggerUpdateEvent &event = {});
+    TriggerManagementOperationResult updateTriggers(TriggerType type, const TriggerUpdateEvent &event = {});
 
     /**
      * Ends the specified types of triggers.
-     * @return Whether there were any active triggers of the specified types.
      */
-    TEST_VIRTUAL bool endTriggers(TriggerTypes types);
+    TriggerManagementOperationResult endTriggers(TriggerTypes types);
 
     /**
      * Cancels the specified types of triggers.
-     * @return Whether there were any active triggers of the specified types.
      */
-    TEST_VIRTUAL bool cancelTriggers(TriggerTypes types);
+    TriggerManagementOperationResult cancelTriggers(TriggerTypes types);
     /**
      * Cancels all triggers leaving only the specified one.
      */

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -131,6 +131,11 @@ public:
     std::shared_ptr<Condition> m_endCondition;
 
     /**
+     * Whether this trigger should block all input events required to perform it while active. Only one active trigger needs this member set to true in order
+     * for events to be blocked.
+     */
+    bool m_blockEvents = true;
+    /**
      * Whether keyboard modifiers should be cleared when this trigger starts. By default true if the trigger has an input action, otherwise false.
      */
     std::optional<bool> m_clearModifiers;

--- a/tests/libinputactions/handlers/TestTriggerHandler.cpp
+++ b/tests/libinputactions/handlers/TestTriggerHandler.cpp
@@ -36,7 +36,7 @@ void TestTriggerHandler::triggers()
     TriggerActivationEvent event;
 
     QCOMPARE(m_handler->triggers(type, event).size(), size);
-    QCOMPARE(m_handler->activateTriggers(type, event), size != 0);
+    QCOMPARE(m_handler->activateTriggers(type, event).success, size != 0);
     QCOMPARE(m_handler->activeTriggers(type).size(), size);
 }
 


### PR DESCRIPTION
New property for [Trigger](https://wiki.inputactions.org/main/trigger.html#properties):
| Property | Type | Description | Default |
|-|-|-|-|
| block_events | *bool* | Whether this trigger should block all input events required to perform it while active. Only one active trigger needs this property set to ``true`` in order for events to be blocked. | ``true`` |

At some point in the future it will be possible to specify exactly which events should be blocked and ``lock_pointer`` will become obsolete.

closes #213