### PR TITLE
libinputactions/variables: add time_since_last_trigger

### DIFF
--- a/src/libinputactions/triggers/Trigger.cpp
+++ b/src/libinputactions/triggers/Trigger.cpp
@@ -95,9 +95,7 @@ void Trigger::update(const TriggerUpdateEvent &event)
         }
     }
 
-    if (m_setLastTrigger) {
-        g_variableManager->getVariable(BuiltinVariables::LastTriggerId)->set(m_id);
-    }
+    setLastTrigger();
     updateActions(event);
 }
 
@@ -114,9 +112,7 @@ void Trigger::end()
     }
 
     qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger ended (id: %1)").arg(m_id);
-    if (m_setLastTrigger) {
-        g_variableManager->getVariable(BuiltinVariables::LastTriggerId)->set(m_id);
-    }
+    setLastTrigger();
     for (const auto &action : m_actions) {
         action->triggerEnded();
     }
@@ -198,6 +194,15 @@ void Trigger::onTick()
 
     for (const auto &action : m_actions) {
         action->triggerTick(TICK_INTERVAL.count());
+    }
+}
+
+void Trigger::setLastTrigger()
+{
+    if (m_setLastTrigger) {
+        g_variableManager->getVariable(BuiltinVariables::LastTriggerId)->set(m_id);
+        g_variableManager->getVariable(BuiltinVariables::LastTriggerTimestamp)
+            ->set(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
     }
 }
 

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -188,6 +188,7 @@ private slots:
     void onTick();
 
 private:
+    void setLastTrigger();
     void reset();
 
     TriggerType m_type{0};

--- a/src/libinputactions/variables/VariableManager.cpp
+++ b/src/libinputactions/variables/VariableManager.cpp
@@ -47,6 +47,7 @@ VariableManager::VariableManager()
         value = g_keyboard->modifiers();
     });
     registerLocalVariable(BuiltinVariables::LastTriggerId);
+    registerLocalVariable(BuiltinVariables::LastTriggerTimestamp, true);
     registerRemoteVariable<QPointF>("pointer_position_screen_percentage", [](auto &value) {
         value = g_pointerPositionGetter->screenPointerPosition();
     });
@@ -67,6 +68,10 @@ VariableManager::VariableManager()
     registerLocalVariable(BuiltinVariables::ThumbInitialPositionPercentage);
     registerLocalVariable(BuiltinVariables::ThumbPositionPercentage);
     registerLocalVariable(BuiltinVariables::ThumbPresent);
+    registerRemoteVariable<qreal>("time_since_last_trigger", [this](auto &value) {
+        value = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count()
+              - getVariable(BuiltinVariables::LastTriggerTimestamp)->get().value_or(0);
+    });
     registerRemoteVariable<QString>("window_class", [](auto &value) {
         if (const auto window = g_windowProvider->activeWindow()) {
             value = window->resourceClass();

--- a/src/libinputactions/variables/VariableManager.h
+++ b/src/libinputactions/variables/VariableManager.h
@@ -50,6 +50,7 @@ struct BuiltinVariables
     inline static const VariableInfo<qreal> Fingers{QStringLiteral("fingers")};
     inline static const VariableInfo<Qt::KeyboardModifiers> KeyboardModifiers{QStringLiteral("keyboard_modifiers")};
     inline static const VariableInfo<QString> LastTriggerId{QStringLiteral("last_trigger_id")};
+    inline static const VariableInfo<qreal> LastTriggerTimestamp{QStringLiteral("last_trigger_timestamp")};
     inline static const VariableInfo<QPointF> ThumbInitialPositionPercentage{QStringLiteral("thumb_initial_position_percentage")};
     inline static const VariableInfo<QPointF> ThumbPositionPercentage{QStringLiteral("thumb_position_percentage")};
     inline static const VariableInfo<bool> ThumbPresent{QStringLiteral("thumb_present")};
@@ -96,14 +97,14 @@ public:
 
     void registerVariable(const QString &name, std::unique_ptr<Variable> variable, bool hidden = false);
     template<typename T>
-    void registerLocalVariable(const QString &name)
+    void registerLocalVariable(const QString &name, bool hidden = false)
     {
-        registerVariable(name, std::make_unique<LocalVariable>(typeid(T)));
+        registerVariable(name, std::make_unique<LocalVariable>(typeid(T)), hidden);
     }
     template<typename T>
-    void registerLocalVariable(const VariableInfo<T> &variable)
+    void registerLocalVariable(const VariableInfo<T> &variable, bool hidden = false)
     {
-        registerLocalVariable<T>(variable.name);
+        registerLocalVariable<T>(variable.name, hidden);
     }
     template<typename T>
     void registerRemoteVariable(const QString &name, const std::function<void(std::optional<T> &value)> getter, bool hidden = false)

--- a/src/libinputactions/variables/VariableOperations.cpp
+++ b/src/libinputactions/variables/VariableOperations.cpp
@@ -18,6 +18,7 @@
 
 #include "VariableOperations.h"
 #include "Variable.h"
+#include <QLocale>
 #include <QLoggingCategory>
 #include <QPointF>
 #include <QRegularExpression>
@@ -187,7 +188,7 @@ QString VariableOperations<bool>::toString(const bool &value)
 template<>
 QString VariableOperations<qreal>::toString(const qreal &value)
 {
-    return QString::number(value);
+    return QString::number(value, 'f', QLocale::FloatingPointShortest);
 }
 
 template<>


### PR DESCRIPTION
Time since ``last_trigger_id`` was set. Useful for double click triggers where the first click doesn't block the event but the second one does (although currently there are various issues that will cause such triggers to break other triggers).

closes #242