### PR TITLE
libinputactions/trigger: allow resumption

### DIFF
--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -930,6 +930,7 @@ struct convert<std::unique_ptr<Trigger>>
         loadMember(trigger->m_id, node["id"]);
         loadMember(trigger->m_mouseButtons, node["mouse_buttons"]);
         loadMember(trigger->m_mouseButtonsExactOrder, node["mouse_buttons_exact_order"]);
+        loadMember(trigger->m_resumeTimeout, node["resume_timeout"]);
         loadMember(trigger->m_setLastTrigger, node["set_last_trigger"]);
         loadMember(trigger->m_threshold, node["threshold"]);
         if (auto *motionTrigger = dynamic_cast<MotionTrigger *>(trigger.get())) {

--- a/src/libinputactions/handlers/TriggerHandler.cpp
+++ b/src/libinputactions/handlers/TriggerHandler.cpp
@@ -66,6 +66,17 @@ TriggerManagementOperationResult TriggerHandler::activateTriggers(TriggerTypes t
     }
     m_timedTriggerUpdateTimer.start();
 
+    for (auto &trigger : m_triggers) {
+        if (!trigger->isResumeTimeoutTimerActive()) {
+            continue;
+        }
+
+        trigger->stopResumeTimeoutTimer();
+        if (!std::ranges::contains(m_activeTriggers, trigger.get())) {
+            trigger->cancel();
+        }
+    }
+
     qCDebug(INPUTACTIONS_HANDLER_TRIGGER).noquote().nospace() << "Triggers activated (count: " << m_activeTriggers.size() << ")";
     return result;
 }

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -94,7 +94,7 @@ public:
      * Resets the trigger and notifies all actions that it has ended.
      * @internal
      */
-    void end();
+    void end(bool allowResuming = true);
 
     /**
      * Resets the trigger and notifies all actions that it has been cancelled.
@@ -116,6 +116,9 @@ public:
      * @internal
      */
     bool overridesOtherTriggersOnUpdate();
+
+    bool isResumeTimeoutTimerActive();
+    void stopResumeTimeoutTimer();
 
     /**
      * Must be satisfied in order for the trigger to be activated.
@@ -168,6 +171,12 @@ public:
      */
     bool m_mouseButtonsExactOrder{};
 
+    /**
+     * The amount of time after a trigger ends, during which the trigger can be performed again is if it never actually ended. Performing any action that does
+     * not activate this trigger causes it to be cancelled immediately.
+     */
+    std::chrono::milliseconds m_resumeTimeout{};
+
     const TriggerType &type() const;
 
 signals:
@@ -186,6 +195,7 @@ protected:
 
 private slots:
     void onTick();
+    void onResumeTimeoutTimerTimeout();
 
 private:
     void setLastTrigger();
@@ -198,6 +208,8 @@ private:
 
     bool m_withinThreshold = false;
     qreal m_absoluteAccumulatedDelta = 0;
+
+    QTimer m_resumeTimeoutTimer;
 
     friend class TestTrigger;
 };


### PR DESCRIPTION
New property for Trigger:
| Property | Type | Description | Default|
|-|-|-|-|
| resume_timeout | *time* | The amount of time after a trigger ends, during which the trigger can be performed again as if it never actually ended. Performing any action that does not activate this trigger causes it to be cancelled immediately.<br><br>Can be used for a drag touchpad gesture that allows lifting fingers. | ``0`` |