### PR TITLE
libinputactions/device: add handle_libevdev_events property

### DIFF
--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -1437,6 +1437,9 @@ struct convert<InputDeviceProperties>
         if (const auto &ignoreNode = node["ignore"]) {
             value.setIgnore(ignoreNode.as<bool>());
         }
+        if (const auto &handleLibevdevEventsNode = node["handle_libevdev_events"]) {
+            value.setHandleLibevdevEvents(handleLibevdevEventsNode.as<bool>());
+        }
         if (const auto &buttonPad = node["buttonpad"]) {
             value.setButtonPad(buttonPad.as<bool>());
         }

--- a/src/libinputactions/input/InputDevice.cpp
+++ b/src/libinputactions/input/InputDevice.cpp
@@ -80,6 +80,7 @@ void InputDeviceProperties::apply(const InputDeviceProperties &other)
 
     apply(m_grab, other.m_grab);
     apply(m_ignore, other.m_ignore);
+    apply(m_handleLibevdevEvents, other.m_handleLibevdevEvents);
     apply(m_multiTouch, other.m_multiTouch);
     apply(m_size, other.m_size);
     apply(m_buttonPad, other.m_buttonPad);
@@ -107,6 +108,16 @@ bool InputDeviceProperties::ignore() const
 void InputDeviceProperties::setIgnore(bool value)
 {
     m_ignore = value;
+}
+
+bool InputDeviceProperties::handleLibevdevEvents() const
+{
+    return m_handleLibevdevEvents.value_or(true);
+}
+
+void InputDeviceProperties::setHandleLibevdevEvents(bool value)
+{
+    m_handleLibevdevEvents = value;
 }
 
 bool InputDeviceProperties::multiTouch() const

--- a/src/libinputactions/input/InputDevice.h
+++ b/src/libinputactions/input/InputDevice.h
@@ -57,6 +57,15 @@ public:
      */
     void setIgnore(bool value);
 
+    /**
+     * @returns Whether to process libevdev events if available.
+     */
+    bool handleLibevdevEvents() const;
+    /**
+     * @see handleLibevdevEvents
+     */
+    void setHandleLibevdevEvents(bool value);
+
     bool multiTouch() const;
     /**
      * Only for testing.
@@ -104,6 +113,7 @@ public:
 private:
     std::optional<bool> m_grab;
     std::optional<bool> m_ignore;
+    std::optional<bool> m_handleLibevdevEvents;
 
     std::optional<bool> m_multiTouch;
     std::optional<QSizeF> m_size;

--- a/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
@@ -104,7 +104,7 @@ void LibevdevComplementaryInputBackend::deviceAdded(InputDevice *device)
         InputBackend::deviceAdded(device);
     });
 
-    if (!m_enabled || device->type() != InputDeviceType::Touchpad) {
+    if (!m_enabled || device->type() != InputDeviceType::Touchpad || !deviceProperties(device).handleLibevdevEvents()) {
         return;
     }
 

--- a/src/standalone/daemon/input/StandaloneInputBackend.cpp
+++ b/src/standalone/daemon/input/StandaloneInputBackend.cpp
@@ -175,14 +175,18 @@ bool StandaloneInputBackend::tryAddEvdevDevice(const QString &path)
         libevdev_set_name(data->libevdev, name.toStdString().c_str());
 
         if (deviceType == InputDeviceType::Touchpad) {
-            LibevdevComplementaryInputBackend::addDevice(device.get(), data->libevdev, false);
+            if (properties.handleLibevdevEvents()) {
+                LibevdevComplementaryInputBackend::addDevice(device.get(), data->libevdev, false);
+            }
 
             connect(&data->touchpadStateResetTimer, &QTimer::timeout, this, [this, device = device.get(), data = data.get()]() {
                 resetDevice(device, data);
             });
         }
     } else {
-        LibevdevComplementaryInputBackend::deviceAdded(device.get());
+        if (properties.handleLibevdevEvents()) {
+            LibevdevComplementaryInputBackend::deviceAdded(device.get());
+        }
     }
 
     if (data->libinputDevice) {
@@ -461,7 +465,9 @@ void StandaloneInputBackend::poll()
             }
 
             frame.push_back(evdevEvent);
-            LibevdevComplementaryInputBackend::handleEvdevEvent(device.get(), evdevEvent);
+            if (device->properties().handleLibevdevEvents()) {
+                LibevdevComplementaryInputBackend::handleEvdevEvent(device.get(), evdevEvent);
+            }
 
             if (evdevEvent.type != EV_SYN) {
                 continue;


### PR DESCRIPTION
New device property:
| Property | Type | Default |
|-|-|-|
| handle_libevdev_events | *bool* | ``true`` |

Makes it possible to disable the libevdev input backend on a per-device basis in case of any issues.