### PR TITLE
standalone: fix name of libinput event injection device

### DIFF
--- a/src/standalone/daemon/input/StandaloneInputBackend.cpp
+++ b/src/standalone/daemon/input/StandaloneInputBackend.cpp
@@ -154,7 +154,7 @@ bool StandaloneInputBackend::tryAddEvdevDevice(const QString &path)
         data->libinputDevice = {};
         data->libinput = libinput_path_create_context(&m_libinputBlockingInterface, nullptr);
 
-        auto virtualDeviceName = name.toStdString() + " (InputActions internal 1)";
+        auto virtualDeviceName = name.toStdString() + " (InputActions internal)";
         libevdev_set_name(data->libevdev, virtualDeviceName.c_str());
         libevdev_uinput_create_from_device(data->libevdev, LIBEVDEV_UINPUT_OPEN_MANAGED, &data->libinputEventInjectionDevice);
         fcntl(libevdev_uinput_get_fd(data->libinputEventInjectionDevice),


### PR DESCRIPTION
`` (InputActions internal 1)`` -> `` (InputActions internal)``