### PR TITLE
libinputactions: implement accelerated actions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(libinputactions_SRCS
     libinputactions/input/backends/InputBackend.cpp
     libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
     libinputactions/input/backends/LibinputInputBackend.cpp
+    libinputactions/input/Delta.cpp
     libinputactions/input/InputDevice.cpp
     libinputactions/input/InputDeviceRule.cpp
     libinputactions/input/events.cpp

--- a/src/hyprland/input/HyprlandInputBackend.cpp
+++ b/src/hyprland/input/HyprlandInputBackend.cpp
@@ -222,7 +222,7 @@ void HyprlandInputBackend::pointerMotion(SCallbackInfo &info, const std::any &da
     const auto pointerPosition = std::any_cast<const Vector2D>(data);
     const auto delta = pointerPosition - m_previousPointerPosition;
     m_previousPointerPosition = pointerPosition;
-    info.cancelled = LibinputInputBackend::pointerMotion(m_currentPointingDevice, QPointF(delta.x, delta.y));
+    info.cancelled = LibinputInputBackend::pointerMotion(m_currentPointingDevice, {{delta.x, delta.y}});
 }
 
 void HyprlandInputBackend::holdBeginHook(void *thisPtr, uint32_t timeMs, uint32_t fingers)
@@ -274,7 +274,7 @@ void HyprlandInputBackend::touchpadSwipeBegin(SCallbackInfo &info, const std::an
 void HyprlandInputBackend::touchpadSwipeUpdate(SCallbackInfo &info, const std::any &data)
 {
     const auto event = std::any_cast<IPointer::SSwipeUpdateEvent>(data);
-    info.cancelled = LibinputInputBackend::touchpadSwipeUpdate(m_currentTouchpad, QPointF(event.delta.x, event.delta.y));
+    info.cancelled = LibinputInputBackend::touchpadSwipeUpdate(m_currentTouchpad, {{event.delta.x, event.delta.y}});
 }
 
 void HyprlandInputBackend::touchpadSwipeEnd(SCallbackInfo &info, const std::any &data)

--- a/src/kwin/input/KWinInputBackend.cpp
+++ b/src/kwin/input/KWinInputBackend.cpp
@@ -108,7 +108,7 @@ bool KWinInputBackend::swipeGestureUpdate(KWin::PointerSwipeGestureUpdateEvent *
 bool KWinInputBackend::swipeGestureUpdate(const QPointF &delta, std::chrono::microseconds time)
 {
 #endif
-    return touchpadSwipeUpdate(currentTouchpad(), delta);
+    return touchpadSwipeUpdate(currentTouchpad(), {delta});
 }
 
 #ifdef KWIN_6_5_OR_GREATER
@@ -189,7 +189,7 @@ bool KWinInputBackend::pointerButton(KWin::PointerButtonEvent *event)
 
 bool KWinInputBackend::pointerMotion(KWin::PointerMotionEvent *event)
 {
-    return LibinputInputBackend::pointerMotion(findInputActionsDevice(event->device), event->delta, event->deltaUnaccelerated);
+    return LibinputInputBackend::pointerMotion(findInputActionsDevice(event->device), {event->delta, event->deltaUnaccelerated});
 }
 
 bool KWinInputBackend::keyboardKey(KWin::KeyboardKeyEvent *event)

--- a/src/libinputactions/actions/TriggerAction.h
+++ b/src/libinputactions/actions/TriggerAction.h
@@ -31,6 +31,8 @@ namespace InputActions
 {
 
 class Action;
+class Delta;
+class PointDelta;
 
 /**
  * The point of the trigger's lifecycle at which the action should be executed.
@@ -110,7 +112,7 @@ public:
      * Called by the trigger.
      * @internal
      */
-    void triggerUpdated(qreal delta, const QPointF &deltaPointMultiplied);
+    void triggerUpdated(const Delta &delta, const PointDelta &deltaPointMultiplied);
     /**
      * Called by the trigger.
      * @internal
@@ -148,6 +150,10 @@ public:
      */
     ActionInterval m_interval;
     /**
+     * Use the accelerated delta for intervals, if available. This does not affect thresholds.
+     */
+    bool m_accelerated{};
+    /**
      * Sets how far the trigger needs to progress in order for the action to be executed. Thresholds are always
      * positive.
      * @remark Begin actions can't have thresholds. Set the threshold on the trigger instead.
@@ -155,7 +161,7 @@ public:
     std::optional<Range<qreal>> m_threshold;
 
 private:
-    void update(qreal delta);
+    void update(const Delta &delta);
 
     /**
      * Resets member variables that hold information about the performed input action.

--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -976,8 +976,11 @@ struct convert<std::unique_ptr<Trigger>>
         }
         trigger->m_activationCondition = conditionGroup;
 
+        const auto accelerated = node["accelerated"].as<bool>(false);
         for (const auto &actionNode : node["actions"]) {
-            trigger->addAction(actionNode.as<std::unique_ptr<TriggerAction>>());
+            auto action = actionNode.as<std::unique_ptr<TriggerAction>>();
+            action->m_accelerated = accelerated;
+            trigger->addAction(std::move(action));
         }
 
         return true;

--- a/src/libinputactions/handlers/MotionTriggerHandler.h
+++ b/src/libinputactions/handlers/MotionTriggerHandler.h
@@ -26,6 +26,8 @@ Q_DECLARE_LOGGING_CATEGORY(INPUTACTIONS_HANDLER_MOTION)
 namespace InputActions
 {
 
+class PointDelta;
+
 enum class Axis
 {
     Horizontal,
@@ -67,7 +69,7 @@ protected:
      * Does nothing if there are no active pinch or rotate triggers.
      * @return Whether there are any active pinch or rotate triggers.
      */
-    bool handleMotion(const QPointF &delta);
+    bool handleMotion(const InputDevice *device, const PointDelta &delta);
 
     /**
      * If false is returned, speed is being determined and methods processing triggers must also return true

--- a/src/libinputactions/handlers/MouseTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MouseTriggerHandler.cpp
@@ -55,7 +55,7 @@ bool MouseTriggerHandler::keyboardKey(const KeyboardKeyEvent &event)
 
 bool MouseTriggerHandler::pointerAxis(const MotionEvent &event)
 {
-    const auto &delta = event.delta();
+    const auto &delta = event.delta().unaccelerated();
     qCDebug(INPUTACTIONS_HANDLER_MOUSE).nospace() << "Event (type: Wheel, delta: " << delta << ")";
 
     if (!hasActiveTriggers(TriggerType::Wheel) && !activateTriggers(TriggerType::Wheel).success) {
@@ -191,16 +191,16 @@ bool MouseTriggerHandler::pointerButton(const PointerButtonEvent &event)
 bool MouseTriggerHandler::pointerMotion(const MotionEvent &event)
 {
     const auto &delta = event.delta();
-    qCDebug(INPUTACTIONS_HANDLER_MOUSE).nospace() << "Event (type: PointerMotion, delta: " << delta << ")";
+    qCDebug(INPUTACTIONS_HANDLER_MOUSE).nospace() << "Event (type: PointerMotion, delta: " << delta.unaccelerated() << ")";
 
     if (m_pressTimeoutTimer.isActive()) {
         qCDebug(INPUTACTIONS_HANDLER_MOUSE, "Event processed (type: PointerMotion, status: PressingButtons)");
         return false;
     }
 
-    m_mouseMotionSinceButtonPress += std::hypot(delta.x(), delta.y());
+    m_mouseMotionSinceButtonPress += delta.unacceleratedHypot();
     if (m_mouseMotionSinceButtonPress < 5) {
-        qCDebug(INPUTACTIONS_HANDLER_MOUSE).nospace() << "Event processed (type: PointerMotion, status: InsufficientMotion, delta: " << delta << ")";
+        qCDebug(INPUTACTIONS_HANDLER_MOUSE).nospace() << "Event processed (type: PointerMotion, status: InsufficientMotion, delta: " << delta.unaccelerated() << ")";
         return false;
     }
 
@@ -218,7 +218,7 @@ bool MouseTriggerHandler::pointerMotion(const MotionEvent &event)
     }
 
     const auto hadActiveGestures = hasActiveTriggers(TriggerType::StrokeSwipe);
-    const auto block = handleMotion(delta);
+    const auto block = handleMotion(event.sender(), delta);
     if (hadActiveGestures && !hasActiveTriggers(TriggerType::StrokeSwipe)) {
         qCDebug(INPUTACTIONS_HANDLER_MOUSE, "Mouse motion gesture ended/cancelled during motion");
         // Swipe gesture cancelled due to wrong speed or direction

--- a/src/libinputactions/handlers/TouchpadTriggerHandler.cpp
+++ b/src/libinputactions/handlers/TouchpadTriggerHandler.cpp
@@ -51,13 +51,13 @@ bool TouchpadTriggerHandler::pointerAxis(const MotionEvent &event)
             activateTriggers(TriggerType::StrokeSwipe);
             [[fallthrough]];
         case State::Scrolling:
-            if (event.delta().isNull()) {
+            if (event.delta().unaccelerated().isNull()) {
                 endTriggers(TriggerType::StrokeSwipe);
                 setState(State::None);
                 return false; // Blocking a (0,0) event breaks kinetic scrolling
             }
 
-            return handleMotion(event.delta());
+            return handleMotion(event.sender(), event.delta());
         default:
             return false;
     }
@@ -115,7 +115,7 @@ bool TouchpadTriggerHandler::pointerMotion(const MotionEvent &event)
             setState(activateTriggers(TriggerType::StrokeSwipe).success ? State::MotionTrigger : State::MotionNoTrigger);
             [[fallthrough]];
         case State::MotionTrigger:
-            return handleMotion(event.delta());
+            return handleMotion(event.sender(), event.delta());
     }
     return false;
 }
@@ -182,7 +182,7 @@ bool TouchpadTriggerHandler::touchpadPinch(const TouchpadPinchEvent &event)
 
 bool TouchpadTriggerHandler::touchpadSwipe(const MotionEvent &event)
 {
-    return handleMotion(event.delta());
+    return handleMotion(event.sender(), event.delta());
 }
 
 void TouchpadTriggerHandler::setState(State state)

--- a/src/libinputactions/input/Delta.cpp
+++ b/src/libinputactions/input/Delta.cpp
@@ -1,0 +1,36 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "Delta.h"
+
+namespace InputActions
+{
+
+qreal PointDelta::acceleratedHypot() const
+{
+    const auto delta = accelerated();
+    return std::hypot(delta.x(), delta.y());
+}
+
+qreal PointDelta::unacceleratedHypot() const
+{
+    const auto delta = unaccelerated();
+    return std::hypot(delta.x(), delta.y());
+}
+
+}

--- a/src/libinputactions/input/Delta.h
+++ b/src/libinputactions/input/Delta.h
@@ -1,0 +1,64 @@
+/*
+    Input Actions - Input handler that executes user-defined actions
+    Copyright (C) 2024-2025 Marcin Woźniak
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QPointF>
+
+namespace InputActions
+{
+
+template<typename T>
+class DeltaBase
+{
+public:
+    DeltaBase(T delta = {})
+        : DeltaBase(delta, delta)
+    {
+    }
+
+    DeltaBase(T accelerated, T unaccelerated)
+        : m_accelerated(accelerated)
+        , m_unaccelerated(unaccelerated)
+    {
+    }
+
+    const T &accelerated() const { return m_accelerated; }
+    const T &unaccelerated() const { return m_unaccelerated; };
+
+private:
+    T m_accelerated;
+    T m_unaccelerated;
+};
+
+class Delta : public DeltaBase<qreal>
+{
+public:
+    using DeltaBase::DeltaBase;
+};
+
+class PointDelta : public DeltaBase<QPointF>
+{
+public:
+    using DeltaBase::DeltaBase;
+
+    qreal acceleratedHypot() const;
+    qreal unacceleratedHypot() const;
+};
+
+}

--- a/src/libinputactions/input/backends/LibinputInputBackend.h
+++ b/src/libinputactions/input/backends/LibinputInputBackend.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <libinputactions/input/backends/LibevdevComplementaryInputBackend.h>
+#include <libinputactions/input/Delta.h>
 
 namespace InputActions
 {
@@ -54,7 +55,7 @@ protected:
      * @param sender The event will be ignored if nullptr.
      * @returns Whether to block the event.
      */
-    bool pointerMotion(InputDevice *sender, const QPointF &delta, QPointF deltaUnaccelerated = {});
+    bool pointerMotion(InputDevice *sender, const PointDelta &delta);
 
     /**
      * @param sender The event will be ignored if nullptr.
@@ -96,7 +97,7 @@ protected:
      * @param sender The event will be ignored if nullptr.
      * @returns Whether to block the event.
      */
-    bool touchpadSwipeUpdate(InputDevice *sender, const QPointF &delta);
+    bool touchpadSwipeUpdate(InputDevice *sender, const PointDelta &delta);
     /**
      * @param sender The event will be ignored if nullptr.
      * @returns Whether to block the event.

--- a/src/libinputactions/input/events.cpp
+++ b/src/libinputactions/input/events.cpp
@@ -37,13 +37,13 @@ InputDevice *InputEvent::sender() const
     return m_sender;
 }
 
-MotionEvent::MotionEvent(InputDevice *sender, InputEventType type, const QPointF &delta)
+MotionEvent::MotionEvent(InputDevice *sender, InputEventType type, PointDelta delta)
     : InputEvent(type, sender)
-    , m_delta(delta)
+    , m_delta(std::move(delta))
 {
 }
 
-const QPointF &MotionEvent::delta() const
+const PointDelta &MotionEvent::delta() const
 {
     return m_delta;
 }

--- a/src/libinputactions/input/events.h
+++ b/src/libinputactions/input/events.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "Delta.h"
 #include "InputDevice.h"
 #include <QKeyCombination>
 #include <QPointF>
@@ -71,12 +72,12 @@ private:
 class MotionEvent : public InputEvent
 {
 public:
-    MotionEvent(InputDevice *sender, InputEventType type, const QPointF &delta);
+    MotionEvent(InputDevice *sender, InputEventType type, PointDelta delta);
 
-    const QPointF &delta() const;
+    const PointDelta &delta() const;
 
 private:
-    QPointF m_delta;
+    PointDelta m_delta;
 };
 
 class KeyboardKeyEvent : public InputEvent

--- a/src/libinputactions/triggers/DirectionalMotionTrigger.cpp
+++ b/src/libinputactions/triggers/DirectionalMotionTrigger.cpp
@@ -50,7 +50,7 @@ void DirectionalMotionTrigger::updateActions(const TriggerUpdateEvent &event)
     };
     auto delta = castedEvent.m_delta;
     if ((m_direction & (m_direction - 1)) == 0 && std::find(negativeDirections.begin(), negativeDirections.end(), m_direction) != negativeDirections.end()) {
-        delta *= -1;
+        delta = {delta.accelerated() * -1, delta.unaccelerated() * -1};
     }
 
     for (auto &action : actions()) {

--- a/src/libinputactions/triggers/MotionTrigger.h
+++ b/src/libinputactions/triggers/MotionTrigger.h
@@ -31,7 +31,7 @@ public:
     // Speed should be in a TriggerBeginEvent, but that's not a thing, and adding it would complicate everything.
     // Not worth it for a single property.
     TriggerSpeed m_speed = TriggerSpeed::Any;
-    QPointF m_deltaMultiplied{};
+    PointDelta m_deltaMultiplied{};
 };
 
 /**

--- a/src/libinputactions/triggers/Trigger.cpp
+++ b/src/libinputactions/triggers/Trigger.cpp
@@ -71,7 +71,8 @@ bool Trigger::endIfCannotUpdate() const
 
 void Trigger::update(const TriggerUpdateEvent &event)
 {
-    m_absoluteAccumulatedDelta += std::abs(event.m_delta);
+    const auto delta = event.m_delta.unaccelerated();
+    m_absoluteAccumulatedDelta += std::abs(delta);
     m_withinThreshold = !m_threshold || m_threshold->contains(m_absoluteAccumulatedDelta);
     if (!m_withinThreshold) {
         qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Threshold not reached (id: %1, current: %2, min: %3, max: %4")
@@ -82,7 +83,7 @@ void Trigger::update(const TriggerUpdateEvent &event)
         return;
     }
 
-    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger updated (id: %1, delta: %2)").arg(m_id, QString::number(event.m_delta));
+    qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger updated (id: %1, delta: %2)").arg(m_id, QString::number(delta));
 
     if (!m_started) {
         qCDebug(INPUTACTIONS_TRIGGER).noquote() << QString("Trigger started (id: %1)").arg(m_id);

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -23,6 +23,7 @@
 #include <QTimer>
 #include <libinputactions/actions/TriggerAction.h>
 #include <libinputactions/conditions/Condition.h>
+#include <libinputactions/input/Delta.h>
 #include <libinputactions/globals.h>
 #include <set>
 
@@ -46,7 +47,7 @@ public:
     TriggerUpdateEvent() = default;
     virtual ~TriggerUpdateEvent() = default;
 
-    qreal m_delta{};
+    Delta m_delta;
 };
 
 /**

--- a/src/standalone/daemon/input/StandaloneInputBackend.cpp
+++ b/src/standalone/daemon/input/StandaloneInputBackend.cpp
@@ -326,8 +326,9 @@ bool StandaloneInputBackend::handleEvent(InputDevice *sender, libinput_event *ev
                 case LIBINPUT_EVENT_GESTURE_SWIPE_BEGIN:
                     return touchpadSwipeBegin(sender, fingers);
                 case LIBINPUT_EVENT_GESTURE_SWIPE_UPDATE: {
-                    const QPointF delta(libinput_event_gesture_get_dx_unaccelerated(gestureEvent), libinput_event_gesture_get_dy_unaccelerated(gestureEvent));
-                    return touchpadSwipeUpdate(sender, delta);
+                    const QPointF acceleratedDelta(libinput_event_gesture_get_dx(gestureEvent), libinput_event_gesture_get_dy(gestureEvent));
+                    const QPointF unacceleratedDelta(libinput_event_gesture_get_dx_unaccelerated(gestureEvent), libinput_event_gesture_get_dy_unaccelerated(gestureEvent));
+                    return touchpadSwipeUpdate(sender, {acceleratedDelta, unacceleratedDelta});
                 }
                 case LIBINPUT_EVENT_GESTURE_SWIPE_END:
                     return touchpadSwipeEnd(sender, cancelled);
@@ -362,7 +363,9 @@ bool StandaloneInputBackend::handleEvent(InputDevice *sender, libinput_event *ev
                     return pointerButton(sender, scanCodeToMouseButton(button), button, state == LIBINPUT_BUTTON_STATE_PRESSED);
                 }
                 case LIBINPUT_EVENT_POINTER_MOTION:
-                    return pointerMotion(sender, {libinput_event_pointer_get_dx(pointerEvent), libinput_event_pointer_get_dy(pointerEvent)});
+                    const QPointF acceleratedDelta(libinput_event_pointer_get_dx(pointerEvent), libinput_event_pointer_get_dy(pointerEvent));
+                    const QPointF unacceleratedDelta(libinput_event_pointer_get_dx_unaccelerated(pointerEvent), libinput_event_pointer_get_dy_unaccelerated(pointerEvent));
+                    return pointerMotion(sender, {acceleratedDelta, unacceleratedDelta});
             }
     }
     return false;

--- a/tests/libinputactions/actions/TestTriggerAction.cpp
+++ b/tests/libinputactions/actions/TestTriggerAction.cpp
@@ -1,6 +1,7 @@
 #include "TestTriggerAction.h"
 #include <libinputactions/actions/Action.h>
 #include <libinputactions/actions/TriggerAction.h>
+#include <libinputactions/input/Delta.h>
 
 namespace InputActions
 {

--- a/tests/libinputactions/handlers/TestPointerTriggerHandler.cpp
+++ b/tests/libinputactions/handlers/TestPointerTriggerHandler.cpp
@@ -21,7 +21,7 @@ void TestPointerTriggerHandler::hover_conditionNotSatisfied_triggerNotActivated(
     PointerTriggerHandler handler;
     handler.addTrigger(std::move(trigger));
 
-    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {1, 0})));
+    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {{1, 0}})));
     QCOMPARE(activatedSpy.count(), 0);
 }
 
@@ -33,7 +33,7 @@ void TestPointerTriggerHandler::hover_conditionSatisfied_triggerActivated()
     PointerTriggerHandler handler;
     handler.addTrigger(std::move(trigger));
 
-    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {1, 0})));
+    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {{1, 0}})));
     QCOMPARE(activatedSpy.count(), 1);
 }
 
@@ -47,12 +47,12 @@ void TestPointerTriggerHandler::hover_conditionNoLongerSatisfied_triggerEnded()
     PointerTriggerHandler handler;
     handler.addTrigger(std::move(trigger));
 
-    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {1, 0})));
+    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {{1, 0}})));
     handler.updateTriggers(TriggerType::Hover);
     QCOMPARE(endedSpy.count(), 0);
 
     satisfied = false;
-    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {1, 0})));
+    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {{1, 0}})));
     QCOMPARE(endedSpy.count(), 1);
 }
 
@@ -66,7 +66,7 @@ void TestPointerTriggerHandler::hover_conditionNoLongerSatisfiedNoMotionEvent_tr
     PointerTriggerHandler handler;
     handler.addTrigger(std::move(trigger));
 
-    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {1, 0})));
+    QVERIFY(!handler.handleEvent(MotionEvent(m_device.get(), InputEventType::PointerMotion, {{1, 0}})));
     handler.updateTriggers(TriggerType::Hover);
     QCOMPARE(endedSpy.count(), 0);
 

--- a/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
+++ b/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
@@ -169,7 +169,7 @@ void TestTouchpadTriggerHandler::swipe1()
 
     addPoints(1);
     movePoints({0.05, 0});
-    QCOMPARE(m_handler->handleEvent(MotionEvent(m_touchpad.get(), InputEventType::PointerMotion, {10, 0})), true);
+    QCOMPARE(m_handler->handleEvent(MotionEvent(m_touchpad.get(), InputEventType::PointerMotion, {{10, 0}})), true);
     QCOMPARE(m_activatingTriggerSpy->count(), 1);
 
     removePoints();
@@ -189,10 +189,10 @@ void TestTouchpadTriggerHandler::swipe2()
     movePoints({0.05, 0});
     movePoints({0.05, 0});
     movePoints({0.05, 0});
-    QCOMPARE(m_handler->handleEvent(MotionEvent(m_touchpad.get(), InputEventType::PointerAxis, {10, 0})), true);
+    QCOMPARE(m_handler->handleEvent(MotionEvent(m_touchpad.get(), InputEventType::PointerAxis, {{10, 0}})), true);
     QCOMPARE(m_activatingTriggerSpy->count(), 1);
 
-    QCOMPARE(m_handler->handleEvent(MotionEvent(m_touchpad.get(), InputEventType::PointerAxis, {0, 0})), false);
+    QCOMPARE(m_handler->handleEvent(MotionEvent(m_touchpad.get(), InputEventType::PointerAxis, {{0, 0}})), false);
     QCOMPARE(m_endingTriggersSpy->count(), 1);
     QCOMPARE(m_endingTriggersSpy->at(0).at(0).value<TriggerTypes>(), TriggerType::StrokeSwipe);
 


### PR DESCRIPTION
New properties for Trigger:

| Property | Type | Description | Default |
|-|-|-|-|
| accelerated | *bool* | Use the accelerated delta (if available) for action intervals. Also applies to the ``move_by_delta`` mouse input action. | ``false`` |

The unaccelerated delta for touchpad swipe gestures is not provided by compositors, therefore it's only available in the standalone implementation. 

Breaking change: in the KWin and standalone implementations, mouse gesture thresholds, intervals, speed and swipe direction change detection use the unaccelerated delta now. On Hyprland the delta is based on cursor motion, so it depends on the device settings.

closes #275