### PR TITLE
standalone/daemon: implement touchpad state synchronization

### DIFF
--- a/src/hyprland/input/HyprlandInputBackend.cpp
+++ b/src/hyprland/input/HyprlandInputBackend.cpp
@@ -25,6 +25,7 @@
 #include <hyprland/src/managers/SeatManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <hyprland/src/protocols/PointerGestures.hpp>
 #undef HANDLE
 #include <libinputactions/input/InputDevice.h>
 
@@ -89,6 +90,22 @@ void HyprlandInputBackend::reset()
     }
     m_devices.clear();
     LibinputInputBackend::reset();
+}
+
+void HyprlandInputBackend::touchpadPinchBlockingStopped(uint32_t fingers)
+{
+    m_ignoreEvents = true;
+    PROTO::pointerGestures->pinchBegin(0, fingers);
+    m_ignoreEvents = false;
+}
+
+void HyprlandInputBackend::touchpadSwipeBlockingStopped(uint32_t fingers)
+{
+    m_ignoreEvents = true;
+    g_pInputManager->onSwipeBegin(IPointer::SSwipeBeginEvent{
+        .fingers = fingers,
+    });
+    m_ignoreEvents = false;
 }
 
 void HyprlandInputBackend::checkDeviceChanges()

--- a/src/hyprland/input/HyprlandInputBackend.h
+++ b/src/hyprland/input/HyprlandInputBackend.h
@@ -51,6 +51,10 @@ public:
     void initialize() override;
     void reset() override;
 
+protected:
+    void touchpadPinchBlockingStopped(uint32_t fingers) override;
+    void touchpadSwipeBlockingStopped(uint32_t fingers) override;
+
 private:
     void checkDeviceChanges();
     void deviceRemoved(const HyprlandInputDevice &device);

--- a/src/hyprland/interfaces/HyprlandInputEmitter.cpp
+++ b/src/hyprland/interfaces/HyprlandInputEmitter.cpp
@@ -22,7 +22,6 @@
 #include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprland/src/managers/SeatManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
-#include <hyprland/src/protocols/PointerGestures.hpp>
 #include <hyprland/src/protocols/core/Compositor.hpp>
 #undef HANDLE
 #include <libinputactions/input/InputDevice.h>
@@ -124,22 +123,6 @@ void HyprlandInputEmitter::mouseMoveRelative(const QPointF &pos)
         .delta = delta,
         .unaccel = delta,
         .device = m_pointer,
-    });
-    g_inputBackend->setIgnoreEvents(false);
-}
-
-void HyprlandInputEmitter::touchpadPinchBegin(uint8_t fingers)
-{
-    g_inputBackend->setIgnoreEvents(true);
-    PROTO::pointerGestures->pinchBegin(0, fingers);
-    g_inputBackend->setIgnoreEvents(false);
-}
-
-void HyprlandInputEmitter::touchpadSwipeBegin(uint8_t fingers)
-{
-    g_inputBackend->setIgnoreEvents(true);
-    g_pInputManager->onSwipeBegin(IPointer::SSwipeBeginEvent{
-        .fingers = fingers,
     });
     g_inputBackend->setIgnoreEvents(false);
 }

--- a/src/hyprland/interfaces/HyprlandInputEmitter.h
+++ b/src/hyprland/interfaces/HyprlandInputEmitter.h
@@ -54,9 +54,6 @@ public:
     void mouseButton(uint32_t button, bool state, const InputActions::InputDevice *device = nullptr) override;
     void mouseMoveRelative(const QPointF &pos) override;
 
-    void touchpadPinchBegin(uint8_t fingers) override;
-    void touchpadSwipeBegin(uint8_t fingers) override;
-
 private:
     void onNewTextInputV3(const WP<CTextInputV3> &textInput);
 

--- a/src/kwin/input/KWinInputBackend.h
+++ b/src/kwin/input/KWinInputBackend.h
@@ -81,6 +81,9 @@ public:
 
     bool keyboardKey(KWin::KeyboardKeyEvent *event) override;
 
+    void touchpadPinchBlockingStopped(uint32_t fingers) override;
+    void touchpadSwipeBlockingStopped(uint32_t fingers) override;
+
 private:
     void kwinDeviceAdded(KWin::InputDevice *kwinDevice);
     void kwinDeviceRemoved(const KWin::InputDevice *kwinDevice);
@@ -92,6 +95,7 @@ private:
 
     bool isMouse(const KWin::InputDevice *device) const;
 
+    KWin::InputRedirection *m_input;
     std::vector<KWinInputDevice> m_devices;
 
     class KeyboardModifierSpy : public KWin::InputEventSpy

--- a/src/kwin/interfaces/KWinInputEmitter.cpp
+++ b/src/kwin/interfaces/KWinInputEmitter.cpp
@@ -125,50 +125,6 @@ void KWinInputEmitter::mouseMoveRelative(const QPointF &pos)
     InputActions::g_inputBackend->setIgnoreEvents(false);
 }
 
-void KWinInputEmitter::touchpadPinchBegin(uint8_t fingers)
-{
-    InputActions::g_inputBackend->setIgnoreEvents(true);
-    const auto time = timestamp();
-#ifdef KWIN_6_5_OR_GREATER
-    KWin::PointerPinchGestureBeginEvent event{
-        .fingerCount = fingers,
-        .time = time,
-    };
-    m_input->processSpies(&KWin::InputEventSpy::pinchGestureBegin, &event);
-    m_input->processFilters(&KWin::InputEventFilter::pinchGestureBegin, &event);
-#else
-    m_input->processSpies([&fingers, &time](auto &&spy) {
-        spy->pinchGestureBegin(fingers, time);
-    });
-    m_input->processFilters([&fingers, &time](auto &&filter) {
-        return filter->pinchGestureBegin(fingers, time);
-    });
-#endif
-    InputActions::g_inputBackend->setIgnoreEvents(false);
-}
-
-void KWinInputEmitter::touchpadSwipeBegin(uint8_t fingers)
-{
-    InputActions::g_inputBackend->setIgnoreEvents(true);
-    const auto time = timestamp();
-#ifdef KWIN_6_5_OR_GREATER
-    KWin::PointerSwipeGestureBeginEvent event{
-        .fingerCount = fingers,
-        .time = time,
-    };
-    m_input->processSpies(&KWin::InputEventSpy::swipeGestureBegin, &event);
-    m_input->processFilters(&KWin::InputEventFilter::swipeGestureBegin, &event);
-#else
-    m_input->processSpies([&fingers, &time](auto &&spy) {
-        spy->swipeGestureBegin(fingers, time);
-    });
-    m_input->processFilters([&fingers, &time](auto &&filter) {
-        return filter->swipeGestureBegin(fingers, time);
-    });
-#endif
-    InputActions::g_inputBackend->setIgnoreEvents(false);
-}
-
 InputDevice *KWinInputEmitter::device() const
 {
     return m_device.get();

--- a/src/kwin/interfaces/KWinInputEmitter.h
+++ b/src/kwin/interfaces/KWinInputEmitter.h
@@ -57,9 +57,6 @@ public:
     void mouseButton(uint32_t button, bool state, const InputActions::InputDevice *target = nullptr) override;
     void mouseMoveRelative(const QPointF &pos) override;
 
-    void touchpadPinchBegin(uint8_t fingers) override;
-    void touchpadSwipeBegin(uint8_t fingers) override;
-
     InputDevice *device() const;
 
 private:

--- a/src/libinputactions/input/backends/LibinputInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibinputInputBackend.cpp
@@ -17,7 +17,6 @@
 */
 
 #include "LibinputInputBackend.h"
-#include <libinputactions/interfaces/InputEmitter.h>
 #include <libinputactions/interfaces/PointerPositionGetter.h>
 #include <libinputactions/interfaces/PointerPositionSetter.h>
 
@@ -139,7 +138,7 @@ bool LibinputInputBackend::touchpadPinchUpdate(InputDevice *sender, qreal scale,
     const auto block = handleEvent(TouchpadPinchEvent(sender, scale, angleDelta));
     if (m_block && !block) {
         // Allow the compositor/client to handle the gesture
-        g_inputEmitter->touchpadPinchBegin(m_fingers);
+        touchpadPinchBlockingStopped(m_fingers);
     }
     m_block = block;
     return block;
@@ -183,7 +182,7 @@ bool LibinputInputBackend::touchpadSwipeUpdate(InputDevice *sender, const PointD
     const auto block = handleEvent(MotionEvent(sender, InputEventType::TouchpadSwipe, delta));
     if (m_block && !block) {
         // Allow the compositor/client to handle the gesture
-        g_inputEmitter->touchpadSwipeBegin(m_fingers);
+        touchpadSwipeBlockingStopped(m_fingers);
     }
     m_block = block;
     return block;

--- a/src/libinputactions/input/backends/LibinputInputBackend.h
+++ b/src/libinputactions/input/backends/LibinputInputBackend.h
@@ -106,6 +106,15 @@ protected:
 
     Qt::MouseButton scanCodeToMouseButton(uint32_t scanCode) const;
 
+    /**
+     * Called when a touchpad pinch update event was not blocked, but the previous one was.
+     */
+    virtual void touchpadPinchBlockingStopped(uint32_t fingers) {}
+    /**
+     * Called when a touchpad swipe update event was not blocked, but the previous one was.
+     */
+    virtual void touchpadSwipeBlockingStopped(uint32_t fingers) {}
+
 private:
     uint32_t m_fingers{};
     bool m_block{};

--- a/src/libinputactions/interfaces/InputEmitter.h
+++ b/src/libinputactions/interfaces/InputEmitter.h
@@ -56,9 +56,6 @@ public:
     virtual void mouseButton(uint32_t button, bool state, const InputDevice *target = nullptr) {}
     virtual void mouseMoveRelative(const QPointF &pos) {}
 
-    virtual void touchpadPinchBegin(uint8_t fingers) {}
-    virtual void touchpadSwipeBegin(uint8_t fingers) {}
-
     /**
      * The implementation may require that all keys that will be used must be registered before initialization. Modifier keys are added by default.
      */

--- a/src/standalone/daemon/input/StandaloneInputBackend.h
+++ b/src/standalone/daemon/input/StandaloneInputBackend.h
@@ -29,6 +29,12 @@
 namespace InputActions
 {
 
+struct LibinputEventsProcessingResult
+{
+    bool block{};
+    uint32_t eventCount{};
+};
+
 class StandaloneInputBackend
     : public QObject
     , public LibinputInputBackend
@@ -63,7 +69,7 @@ private:
     void evdevDeviceRemoved(const QString &path);
 
     bool handleEvent(InputDevice *sender, libinput_event *event);
-    bool handleLibinputEvents(InputDevice *device, libinput *libinput);
+    LibinputEventsProcessingResult handleLibinputEvents(InputDevice *device, libinput *libinput);
 
     /**
      * @return Whether the specified device is in a neutral state.
@@ -73,6 +79,10 @@ private:
      * Resets the output device of the specified grabbed device into a neutral state.
      */
     void resetDevice(const InputDevice *device, const ExtraDeviceData *data);
+    /**
+     * Copies the current state of the specified grabbed touchpad to its neutral output device.
+     */
+    void copyTouchpadState(const ExtraDeviceData *data) const;
 
     libinput_interface m_libinputBlockingInterface;
     libinput_interface m_libinputNonBlockingInterface;


### PR DESCRIPTION
If touchpad events suddenly stop being blocked (direction change, wrong speed etc.) but the device is not in a neutral state, the state will be copied to the output device (which will be in a neutral state), effectively "unblocking" the touchpad.