### PR TITLE
daemon: fix multi-session security vulnerabilities

### DIFF
--- a/src/libinputactions/actions/ActionExecutor.cpp
+++ b/src/libinputactions/actions/ActionExecutor.cpp
@@ -49,4 +49,16 @@ void ActionExecutor::execute(const std::shared_ptr<Action> &action, ActionThread
     }
 }
 
+void ActionExecutor::clearQueue()
+{
+    m_ownActionThreadPool.clear();
+    m_sharedActionThreadPool.clear();
+}
+
+void ActionExecutor::waitForDone()
+{
+    m_ownActionThreadPool.waitForDone();
+    m_sharedActionThreadPool.waitForDone();
+}
+
 }

--- a/src/libinputactions/actions/ActionExecutor.h
+++ b/src/libinputactions/actions/ActionExecutor.h
@@ -53,6 +53,15 @@ public:
      */
     void execute(const std::shared_ptr<Action> &action, ActionThread thread = ActionThread::Auto);
 
+    /**
+     * Clears the action queue.
+     */
+    void clearQueue();
+    /**
+     * Waits for all actions to finish execution.
+     */
+    void waitForDone();
+
 private:
     /**
      * Consists of one thread, shared across all actions.


### PR DESCRIPTION
This fixes two issues in the standalone implementation:
- a user may execute actions (including commands) in another user's session if it has a running InputActions client,
- if a session with a different config is activated but that config does not load properly, the previous config remains active.