### PR TITLE
libinputactions: add emergency combination

### DIFF
--- a/src/hyprland/input/HyprlandInputBackend.cpp
+++ b/src/hyprland/input/HyprlandInputBackend.cpp
@@ -208,7 +208,7 @@ void HyprlandInputBackend::keyboardKey(SCallbackInfo &info, const std::any &data
 
     auto *device = findInputActionsDevice(keyboard.get());
     if (device) {
-        device->updateModifiers(event.keycode, state);
+        device->setKeyState(event.keycode, state);
     }
     info.cancelled = LibinputInputBackend::keyboardKey(device, event.keycode, state);
 }

--- a/src/hyprland/input/HyprlandInputBackend.h
+++ b/src/hyprland/input/HyprlandInputBackend.h
@@ -40,9 +40,7 @@ struct HyprlandInputDevice
 /**
  * Hold and pinch touchpad gestures require hooking, and therefore only work on x86_64.
  */
-class HyprlandInputBackend
-    : public QObject
-    , public InputActions::LibinputInputBackend
+class HyprlandInputBackend : public InputActions::LibinputInputBackend
 {
 public:
     HyprlandInputBackend(void *handle);

--- a/src/kwin/input/KWinInputBackend.cpp
+++ b/src/kwin/input/KWinInputBackend.cpp
@@ -310,6 +310,6 @@ void KWinInputBackend::KeyboardModifierSpy::keyboardKey(KWin::KeyboardKeyEvent *
     }
 
     if (auto *device = backend->findInputActionsDevice(event->device)) {
-        device->updateModifiers(event->nativeScanCode, event->state == KWin::KeyboardKeyState::Pressed);
+        device->setKeyState(event->nativeScanCode, event->state == KWin::KeyboardKeyState::Pressed);
     }
 }

--- a/src/kwin/input/KWinInputBackend.h
+++ b/src/kwin/input/KWinInputBackend.h
@@ -34,8 +34,7 @@ struct KWinInputDevice
  * next filter.
  */
 class KWinInputBackend
-    : public QObject
-    , public InputActions::LibinputInputBackend
+    : public InputActions::LibinputInputBackend
     , public KWin::InputEventFilter
 {
 public:

--- a/src/libinputactions/InputActionsMain.cpp
+++ b/src/libinputactions/InputActionsMain.cpp
@@ -90,7 +90,7 @@ void InputActionsMain::setMissingImplementations()
 }
 
 void InputActionsMain::registerGlobalVariables(VariableManager *variableManager, std::shared_ptr<PointerPositionGetter> pointerPositionGetter,
-                                           std::shared_ptr<WindowProvider> windowProvider)
+                                               std::shared_ptr<WindowProvider> windowProvider)
 {
     if (!pointerPositionGetter) {
         pointerPositionGetter = g_pointerPositionGetter;

--- a/src/libinputactions/handlers/MotionTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MotionTriggerHandler.cpp
@@ -69,7 +69,8 @@ bool MotionTriggerHandler::handleMotion(const InputDevice *device, const PointDe
 
     m_deltas.push_back(delta.unaccelerated());
     m_currentSwipeDelta += delta.unaccelerated();
-    m_averageSwipeDelta = (m_deltas.size() * m_averageSwipeDelta + QPointF(std::abs(delta.unaccelerated().x()), std::abs(delta.unaccelerated().y()))) / (m_deltas.size() + 1);
+    m_averageSwipeDelta = (m_deltas.size() * m_averageSwipeDelta + QPointF(std::abs(delta.unaccelerated().x()), std::abs(delta.unaccelerated().y())))
+                        / (m_deltas.size() + 1);
 
     TriggerSpeed speed{};
     if (!determineSpeed(TriggerType::Swipe, delta.unacceleratedHypot(), speed)) {
@@ -116,7 +117,8 @@ bool MotionTriggerHandler::handleMotion(const InputDevice *device, const PointDe
                 Q_UNREACHABLE();
         }
 
-        swipeEvent.m_delta = m_currentSwipeAxis == Axis::Vertical ? Delta(delta.accelerated().y(), delta.unaccelerated().y()) : Delta(delta.accelerated().x(), delta.unaccelerated().x());
+        swipeEvent.m_delta = m_currentSwipeAxis == Axis::Vertical ? Delta(delta.accelerated().y(), delta.unaccelerated().y())
+                                                                  : Delta(delta.accelerated().x(), delta.unaccelerated().x());
         swipeEvent.m_direction = static_cast<TriggerDirection>(direction);
         swipeEvent.m_deltaMultiplied = {delta.accelerated() * m_swipeDeltaMultiplier, delta.unaccelerated() * m_swipeDeltaMultiplier};
         swipeEvent.m_speed = speed;

--- a/src/libinputactions/handlers/MouseTriggerHandler.cpp
+++ b/src/libinputactions/handlers/MouseTriggerHandler.cpp
@@ -200,7 +200,8 @@ bool MouseTriggerHandler::pointerMotion(const MotionEvent &event)
 
     m_mouseMotionSinceButtonPress += delta.unacceleratedHypot();
     if (m_mouseMotionSinceButtonPress < 5) {
-        qCDebug(INPUTACTIONS_HANDLER_MOUSE).nospace() << "Event processed (type: PointerMotion, status: InsufficientMotion, delta: " << delta.unaccelerated() << ")";
+        qCDebug(INPUTACTIONS_HANDLER_MOUSE).nospace() << "Event processed (type: PointerMotion, status: InsufficientMotion, delta: " << delta.unaccelerated()
+                                                      << ")";
         return false;
     }
 

--- a/src/libinputactions/input/InputDevice.cpp
+++ b/src/libinputactions/input/InputDevice.cpp
@@ -31,26 +31,29 @@ InputDevice::InputDevice(InputDeviceType type, QString name, QString sysName)
 
 InputDevice::~InputDevice() = default;
 
-void InputDevice::updateModifiers(uint32_t key, bool state)
+Qt::KeyboardModifiers InputDevice::modifiers() const
 {
-    Qt::KeyboardModifier modifier{};
-    if (KEYBOARD_MODIFIERS.contains(key)) {
-        modifier = KEYBOARD_MODIFIERS.at(key);
+    Qt::KeyboardModifiers modifiers;
+    for (const auto &[key, modifier] : KEYBOARD_MODIFIERS) {
+        if (m_keys.contains(key)) {
+            modifiers |= modifier;
+        }
     }
-    if (!modifier) {
-        return;
-    }
-
-    if (state) {
-        m_modifiers |= modifier;
-    } else {
-        m_modifiers &= ~modifier;
-    }
+    return modifiers;
 }
 
-const Qt::KeyboardModifiers &InputDevice::modifiers() const
+const std::unordered_set<uint32_t> &InputDevice::keys() const
 {
-    return m_modifiers;
+    return m_keys;
+}
+
+void InputDevice::setKeyState(uint32_t key, bool state)
+{
+    if (state) {
+        m_keys.insert(key);
+    } else {
+        m_keys.erase(key);
+    }
 }
 
 const InputDeviceType &InputDevice::type() const

--- a/src/libinputactions/input/InputDevice.h
+++ b/src/libinputactions/input/InputDevice.h
@@ -24,6 +24,7 @@
 #include <libinputactions/globals.h>
 #include <linux/input-event-codes.h>
 #include <optional>
+#include <unordered_set>
 
 namespace InputActions
 {
@@ -177,11 +178,16 @@ public:
     InputDevice(InputDeviceType type, QString name = {}, QString sysName = {});
     ~InputDevice();
 
-    const Qt::KeyboardModifiers &modifiers() const;
     /**
-     * Non-modifier key events will be ignored.
+     * Current keyboard modifiers, derived from pressed keyboard keys.
      */
-    void updateModifiers(uint32_t key, bool state);
+    Qt::KeyboardModifiers modifiers() const;
+
+    /**
+     * Currently pressed keyboard keys.
+     */
+    const std::unordered_set<uint32_t> &keys() const;
+    void setKeyState(uint32_t key, bool state);
 
     const InputDeviceType &type() const;
     const QString &name() const;
@@ -203,7 +209,7 @@ private:
     QString m_sysName;
     InputDeviceProperties m_properties;
 
-    Qt::KeyboardModifiers m_modifiers{};
+    std::unordered_set<uint32_t> m_keys;
 };
 
 }

--- a/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.h
+++ b/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.h
@@ -32,7 +32,7 @@ namespace InputActions
  *
  * Emitted events: TouchpadClick, TouchpadSlot
  */
-class LibevdevComplementaryInputBackend : public virtual InputBackend
+class LibevdevComplementaryInputBackend : public InputBackend
 {
 public:
     LibevdevComplementaryInputBackend();

--- a/src/libinputactions/input/backends/LibinputInputBackend.h
+++ b/src/libinputactions/input/backends/LibinputInputBackend.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include <libinputactions/input/backends/LibevdevComplementaryInputBackend.h>
 #include <libinputactions/input/Delta.h>
+#include <libinputactions/input/backends/LibevdevComplementaryInputBackend.h>
 
 namespace InputActions
 {
@@ -33,7 +33,7 @@ protected:
     LibinputInputBackend() = default;
 
     /**
-     * Keyboard::updateModifiers must be called prior to this method.
+     * InputDevice::setKeyState must be called prior to this method.
      * @param sender The event will be ignored if nullptr.
      * @returns Whether to block the event.
      */

--- a/src/libinputactions/triggers/Trigger.h
+++ b/src/libinputactions/triggers/Trigger.h
@@ -23,8 +23,8 @@
 #include <QTimer>
 #include <libinputactions/actions/TriggerAction.h>
 #include <libinputactions/conditions/Condition.h>
-#include <libinputactions/input/Delta.h>
 #include <libinputactions/globals.h>
+#include <libinputactions/input/Delta.h>
 #include <set>
 
 Q_DECLARE_LOGGING_CATEGORY(INPUTACTIONS_TRIGGER)

--- a/src/standalone/daemon/input/StandaloneInputBackend.cpp
+++ b/src/standalone/daemon/input/StandaloneInputBackend.cpp
@@ -337,7 +337,8 @@ bool StandaloneInputBackend::handleEvent(InputDevice *sender, libinput_event *ev
                     return touchpadSwipeBegin(sender, fingers);
                 case LIBINPUT_EVENT_GESTURE_SWIPE_UPDATE: {
                     const QPointF acceleratedDelta(libinput_event_gesture_get_dx(gestureEvent), libinput_event_gesture_get_dy(gestureEvent));
-                    const QPointF unacceleratedDelta(libinput_event_gesture_get_dx_unaccelerated(gestureEvent), libinput_event_gesture_get_dy_unaccelerated(gestureEvent));
+                    const QPointF unacceleratedDelta(libinput_event_gesture_get_dx_unaccelerated(gestureEvent),
+                                                     libinput_event_gesture_get_dy_unaccelerated(gestureEvent));
                     return touchpadSwipeUpdate(sender, {acceleratedDelta, unacceleratedDelta});
                 }
                 case LIBINPUT_EVENT_GESTURE_SWIPE_END:
@@ -350,7 +351,7 @@ bool StandaloneInputBackend::handleEvent(InputDevice *sender, libinput_event *ev
             const auto key = libinput_event_keyboard_get_key(keyboardEvent);
             const auto state = libinput_event_keyboard_get_key_state(keyboardEvent) == LIBINPUT_KEY_STATE_PRESSED;
 
-            sender->updateModifiers(key, state);
+            sender->setKeyState(key, state);
             return keyboardKey(sender,
                                libinput_event_keyboard_get_key(keyboardEvent),
                                libinput_event_keyboard_get_key_state(keyboardEvent) == LIBINPUT_KEY_STATE_PRESSED);
@@ -374,7 +375,8 @@ bool StandaloneInputBackend::handleEvent(InputDevice *sender, libinput_event *ev
                 }
                 case LIBINPUT_EVENT_POINTER_MOTION:
                     const QPointF acceleratedDelta(libinput_event_pointer_get_dx(pointerEvent), libinput_event_pointer_get_dy(pointerEvent));
-                    const QPointF unacceleratedDelta(libinput_event_pointer_get_dx_unaccelerated(pointerEvent), libinput_event_pointer_get_dy_unaccelerated(pointerEvent));
+                    const QPointF unacceleratedDelta(libinput_event_pointer_get_dx_unaccelerated(pointerEvent),
+                                                     libinput_event_pointer_get_dy_unaccelerated(pointerEvent));
                     return pointerMotion(sender, {acceleratedDelta, unacceleratedDelta});
             }
     }

--- a/src/standalone/daemon/input/StandaloneInputBackend.h
+++ b/src/standalone/daemon/input/StandaloneInputBackend.h
@@ -35,9 +35,7 @@ struct LibinputEventsProcessingResult
     uint32_t eventCount{};
 };
 
-class StandaloneInputBackend
-    : public QObject
-    , public LibinputInputBackend
+class StandaloneInputBackend : public LibinputInputBackend
 {
     Q_OBJECT
 


### PR DESCRIPTION
The emergency combination (backspace+space+enter in any order held for 2 seconds) will reset InputActions, which may be useful if a configuration renders the session unusable. I'll make it configurable later.