### PR TITLE
libinputactions: merge wheel action executions

### DIFF
--- a/src/libinputactions/actions/Action.cpp
+++ b/src/libinputactions/actions/Action.cpp
@@ -36,13 +36,21 @@ void Action::aboutToExecute()
     m_executions++;
 }
 
-void Action::execute()
+void Action::execute(uint32_t executions)
 {
+    Q_ASSERT(executions != 0);
+    Q_ASSERT(executions == 1 || mergeable());
+
     qCDebug(INPUTACTIONS) << QString("Executing action \"%1\"").arg(m_id);
-    executeImpl();
+    executeImpl(executions);
 }
 
 bool Action::async() const
+{
+    return false;
+}
+
+bool Action::mergeable() const
 {
     return false;
 }

--- a/src/libinputactions/actions/Action.h
+++ b/src/libinputactions/actions/Action.h
@@ -47,12 +47,16 @@ public:
      * @see executeImpl
      * @internal
      */
-    void execute();
+    void execute(uint32_t executions);
     /**
      * Whether the action should be executed asynchronously. A value of false does not guarantee that the action will be executed synchronously.
      * @see ActionExecutor::execute
      */
     virtual bool async() const;
+    /**
+     * Whether multiple executions of this action can be merged together.
+     */
+    virtual bool mergeable() const;
 
     void reset();
 
@@ -78,8 +82,9 @@ public:
 protected:
     /**
      * This method is not guaranteed to be called from the main thread.
+     * @param executions If the action is mergeable, this is set to the intended execution count, otherwise 1. Must not be 0.
      */
-    virtual void executeImpl() {};
+    virtual void executeImpl(uint32_t executions) {}
 };
 
 }

--- a/src/libinputactions/actions/ActionExecutor.cpp
+++ b/src/libinputactions/actions/ActionExecutor.cpp
@@ -27,13 +27,13 @@ ActionExecutor::ActionExecutor()
     m_sharedActionThreadPool.setMaxThreadCount(1);
 }
 
-void ActionExecutor::execute(const std::shared_ptr<Action> &action, ActionThread thread)
+void ActionExecutor::execute(const std::shared_ptr<Action> &action, ActionExecutionArguments &&arguments)
 {
-    const auto execute = [action = action]() { // copy action in case config gets reloaded while actions are scheduled
-        action->execute();
+    const auto execute = [action = action, executions = arguments.executions]() { // copy action in case config gets reloaded while actions are scheduled
+        action->execute(executions);
     };
     action->aboutToExecute();
-    switch (thread) {
+    switch (arguments.thread) {
         case ActionThread::Auto:
             if (action->async() || m_sharedActionThreadPool.activeThreadCount()) {
                 m_sharedActionThreadPool.start(execute);

--- a/src/libinputactions/actions/ActionExecutor.h
+++ b/src/libinputactions/actions/ActionExecutor.h
@@ -42,6 +42,18 @@ enum class ActionThread
     Own,
 };
 
+struct ActionExecutionArguments
+{
+    /**
+     * Must be 1 if the action is not mergeable.
+     */
+    uint32_t executions = 1;
+    /**
+     * Which thread to execute the action on.
+     */
+    ActionThread thread = ActionThread::Auto;
+};
+
 class ActionExecutor
 {
 public:
@@ -49,9 +61,8 @@ public:
 
     /**
      * Executes an action without checking its condition.
-     * @param thread Which thread to execute the action on.
      */
-    void execute(const std::shared_ptr<Action> &action, ActionThread thread = ActionThread::Auto);
+    void execute(const std::shared_ptr<Action> &action, ActionExecutionArguments &&arguments = {});
 
     /**
      * Clears the action queue.

--- a/src/libinputactions/actions/ActionGroup.cpp
+++ b/src/libinputactions/actions/ActionGroup.cpp
@@ -31,7 +31,7 @@ ActionGroup::ActionGroup(std::vector<std::shared_ptr<Action>> actions, Execution
 {
 }
 
-void ActionGroup::executeImpl()
+void ActionGroup::executeImpl(uint32_t executions)
 {
     // TODO Each action with a condition introduces latency
     const auto evaluateCondition = [](const auto &action) {
@@ -55,13 +55,17 @@ void ActionGroup::executeImpl()
                 if (!evaluateCondition(action)) {
                     continue;
                 }
-                g_actionExecutor->execute(action, ActionThread::Current);
+                g_actionExecutor->execute(action, {
+                    .thread = ActionThread::Current,
+                });
             }
             break;
         case ExecutionMode::First:
             for (const auto &action : m_actions) {
                 if (evaluateCondition(action)) {
-                    g_actionExecutor->execute(action, ActionThread::Current);
+                    g_actionExecutor->execute(action, {
+                        .thread = ActionThread::Current,
+                    });
                     break;
                 }
             }

--- a/src/libinputactions/actions/ActionGroup.h
+++ b/src/libinputactions/actions/ActionGroup.h
@@ -47,7 +47,7 @@ public:
     bool async() const override;
 
 protected:
-    void executeImpl() override;
+    void executeImpl(uint32_t executions) override;
 
 private:
     std::vector<std::shared_ptr<Action>> m_actions;

--- a/src/libinputactions/actions/CommandAction.cpp
+++ b/src/libinputactions/actions/CommandAction.cpp
@@ -32,7 +32,7 @@ bool CommandAction::async() const
     return m_wait || m_command.expensive();
 }
 
-void CommandAction::executeImpl()
+void CommandAction::executeImpl(uint32_t executions)
 {
     const auto command = m_command.get().value_or("");
     if (command.isEmpty()) {

--- a/src/libinputactions/actions/CommandAction.h
+++ b/src/libinputactions/actions/CommandAction.h
@@ -45,7 +45,7 @@ public:
     bool m_wait{};
 
 protected:
-    void executeImpl() override;
+    void executeImpl(uint32_t executions) override;
 
 private:
     Value<QString> m_command;

--- a/src/libinputactions/actions/CustomAction.cpp
+++ b/src/libinputactions/actions/CustomAction.cpp
@@ -21,9 +21,10 @@
 namespace InputActions
 {
 
-CustomAction::CustomAction(std::function<void()> function, bool async)
+CustomAction::CustomAction(std::function<void(uint32_t executions)> function, bool async, bool mergeable)
     : m_function(std::move(function))
     , m_async(async)
+    , m_mergeable(mergeable)
 {
 }
 
@@ -32,9 +33,14 @@ bool CustomAction::async() const
     return m_async;
 }
 
-void CustomAction::executeImpl()
+bool CustomAction::mergeable() const
 {
-    m_function();
+    return m_mergeable;
+}
+
+void CustomAction::executeImpl(uint32_t executions)
+{
+    m_function(executions);
 }
 
 }

--- a/src/libinputactions/actions/CustomAction.h
+++ b/src/libinputactions/actions/CustomAction.h
@@ -30,16 +30,18 @@ public:
     /**
      * @param async See ActionExecutor::async()
      */
-    CustomAction(std::function<void()> function, bool async = false);
+    CustomAction(std::function<void(uint32_t executions)> function, bool async = false, bool mergeable = false);
 
     bool async() const override;
+    bool mergeable() const override;
 
 protected:
-    void executeImpl() override;
+    void executeImpl(uint32_t executions) override;
 
 private:
-    std::function<void()> m_function;
+    std::function<void(uint32_t executions)> m_function;
     bool m_async;
+    bool m_mergeable;
 };
 
 }

--- a/src/libinputactions/actions/InputAction.h
+++ b/src/libinputactions/actions/InputAction.h
@@ -50,6 +50,7 @@ public:
     InputAction(std::vector<Item> sequence);
 
     bool async() const override;
+    bool mergeable() const override;
 
     /**
      * Delay between each item in the sequence.
@@ -62,7 +63,7 @@ public:
     QPointF m_deltaMultiplied;
 
 protected:
-    void executeImpl() override;
+    void executeImpl(uint32_t executions) override;
 
 private:
     std::vector<Item> m_sequence;

--- a/src/libinputactions/actions/PlasmaGlobalShortcutAction.cpp
+++ b/src/libinputactions/actions/PlasmaGlobalShortcutAction.cpp
@@ -28,7 +28,7 @@ PlasmaGlobalShortcutAction::PlasmaGlobalShortcutAction(QString component, QStrin
 {
 }
 
-void PlasmaGlobalShortcutAction::executeImpl()
+void PlasmaGlobalShortcutAction::executeImpl(uint32_t executions)
 {
     g_plasmaGlobalShortcutInvoker->invoke(m_component, m_shortcut);
 }

--- a/src/libinputactions/actions/PlasmaGlobalShortcutAction.h
+++ b/src/libinputactions/actions/PlasmaGlobalShortcutAction.h
@@ -30,7 +30,7 @@ public:
     PlasmaGlobalShortcutAction(QString component, QString shortcut);
 
 protected:
-    void executeImpl() override;
+    void executeImpl(uint32_t executions) override;
 
 private:
     QString m_component;

--- a/src/libinputactions/actions/SleepAction.cpp
+++ b/src/libinputactions/actions/SleepAction.cpp
@@ -32,7 +32,7 @@ bool SleepAction::async() const
     return true;
 }
 
-void SleepAction::executeImpl()
+void SleepAction::executeImpl(uint32_t executions)
 {
     QThread::msleep(m_time.count());
 }

--- a/src/libinputactions/actions/SleepAction.h
+++ b/src/libinputactions/actions/SleepAction.h
@@ -32,7 +32,7 @@ public:
     bool async() const override;
 
 protected:
-    void executeImpl() override;
+    void executeImpl(uint32_t executions) override;
 
 private:
     std::chrono::milliseconds m_time;

--- a/src/libinputactions/actions/TriggerAction.h
+++ b/src/libinputactions/actions/TriggerAction.h
@@ -131,9 +131,10 @@ public:
 
     /**
      * Executes the action if it can be executed.
+     * @param executions Must be 1 if the action is not mergeable.
      * @see canExecute
      */
-    void tryExecute();
+    void tryExecute(uint32_t executions = 1);
     /**
      * @return Whether the condition and threshold are satisfied.
      */

--- a/tests/libinputactions/actions/TestActionExecutor.cpp
+++ b/tests/libinputactions/actions/TestActionExecutor.cpp
@@ -12,7 +12,7 @@ void TestActionExecutor::init()
 
 void TestActionExecutor::execute_syncAction_executedOnMainThread()
 {
-    m_executor->execute(std::make_shared<CustomAction>([]() {
+    m_executor->execute(std::make_shared<CustomAction>([](auto) {
         QVERIFY(isMainThread());
     }));
 }
@@ -20,7 +20,7 @@ void TestActionExecutor::execute_syncAction_executedOnMainThread()
 void TestActionExecutor::execute_asyncAction_executedOnActionThread()
 {
     m_executor->execute(std::make_shared<CustomAction>(
-        []() {
+        [](auto) {
             QVERIFY(!isMainThread());
         },
         true));
@@ -30,7 +30,7 @@ void TestActionExecutor::execute_asyncAction_executedOnActionThread()
 void TestActionExecutor::execute_syncActionWhileActionThreadIsBusy_executedOnActionThread()
 {
     m_executor->execute(std::make_shared<SleepAction>(std::chrono::milliseconds(100U)));
-    m_executor->execute(std::make_shared<CustomAction>([]() {
+    m_executor->execute(std::make_shared<CustomAction>([](auto) {
         QVERIFY(!isMainThread());
     }));
     QTest::qWait(500);
@@ -39,25 +39,25 @@ void TestActionExecutor::execute_syncActionWhileActionThreadIsBusy_executedOnAct
 void TestActionExecutor::execute_syncAndAsyncActions_orderPreserved()
 {
     std::vector<uint8_t> results;
-    m_executor->execute(std::make_shared<CustomAction>([&results]() {
+    m_executor->execute(std::make_shared<CustomAction>([&results](auto) {
         results.push_back(1);
     }));
     m_executor->execute(std::make_shared<CustomAction>(
-        [&results]() {
+        [&results](auto) {
             QTest::qWait(20);
             results.push_back(2);
         },
         true));
-    m_executor->execute(std::make_shared<CustomAction>([&results]() {
+    m_executor->execute(std::make_shared<CustomAction>([&results](auto) {
         results.push_back(3);
     }));
     m_executor->execute(std::make_shared<CustomAction>(
-        [&results]() {
+        [&results](auto) {
             QTest::qWait(10);
             results.push_back(4);
         },
         true));
-    m_executor->execute(std::make_shared<CustomAction>([&results]() {
+    m_executor->execute(std::make_shared<CustomAction>([&results](auto) {
         results.push_back(5);
     }));
     QTest::qWait(50);

--- a/tests/libinputactions/actions/TestTriggerAction.cpp
+++ b/tests/libinputactions/actions/TestTriggerAction.cpp
@@ -1,5 +1,6 @@
 #include "TestTriggerAction.h"
 #include <libinputactions/actions/Action.h>
+#include <libinputactions/actions/CustomAction.h>
 #include <libinputactions/actions/TriggerAction.h>
 #include <libinputactions/input/Delta.h>
 
@@ -42,6 +43,23 @@ void TestTriggerAction::triggerUpdated_intervals()
     }
 
     QCOMPARE(action->action()->m_executions, executions);
+}
+
+void TestTriggerAction::triggerUpdated_mergeable()
+{
+    uint32_t actualExecutions{};
+    auto action = std::make_unique<TriggerAction>(std::make_shared<CustomAction>([&actualExecutions](auto executions) {
+        actualExecutions = executions;
+    }, false, true));
+
+    ActionInterval interval{};
+    interval.setValue(1);
+    action->m_on = On::Update;
+    action->m_interval = interval;
+
+    action->triggerUpdated(10, {});
+
+    QCOMPARE(actualExecutions, 10);
 }
 
 }

--- a/tests/libinputactions/actions/TestTriggerAction.h
+++ b/tests/libinputactions/actions/TestTriggerAction.h
@@ -12,6 +12,8 @@ class TestTriggerAction : public Test
 private slots:
     void triggerUpdated_intervals_data();
     void triggerUpdated_intervals();
+
+    void triggerUpdated_mergeable();
 };
 
 }


### PR DESCRIPTION
Firefox doesn't like receiving hundreds of pointer axis events per second during circular scrolling.