### PR TITLE
{hyprland,kwin}: merge pointer axis events

### DIFF
--- a/src/hyprland/input/HyprlandInputBackend.cpp
+++ b/src/hyprland/input/HyprlandInputBackend.cpp
@@ -222,7 +222,7 @@ void HyprlandInputBackend::pointerAxis(SCallbackInfo &info, const std::any &data
     if (event.relativeDirection == WL_POINTER_AXIS_RELATIVE_DIRECTION_INVERTED) {
         delta *= -1;
     }
-    info.cancelled = LibinputInputBackend::pointerAxis(m_currentPointingDevice, delta);
+    info.cancelled = LibinputInputBackend::pointerAxis(m_currentPointingDevice, delta, true);
 }
 
 void HyprlandInputBackend::pointerButton(SCallbackInfo &info, const std::any &data)

--- a/src/kwin/input/KWinInputBackend.cpp
+++ b/src/kwin/input/KWinInputBackend.cpp
@@ -177,7 +177,7 @@ bool KWinInputBackend::pointerAxis(KWin::PointerAxisEvent *event)
     if (event->inverted) {
         delta *= -1;
     }
-    return LibinputInputBackend::pointerAxis(findInputActionsDevice(event->device), delta);
+    return LibinputInputBackend::pointerAxis(findInputActionsDevice(event->device), delta, true);
 }
 
 bool KWinInputBackend::pointerButton(KWin::PointerButtonEvent *event)

--- a/src/libinputactions/actions/ActionGroup.cpp
+++ b/src/libinputactions/actions/ActionGroup.cpp
@@ -55,17 +55,19 @@ void ActionGroup::executeImpl(uint32_t executions)
                 if (!evaluateCondition(action)) {
                     continue;
                 }
-                g_actionExecutor->execute(action, {
-                    .thread = ActionThread::Current,
-                });
+                g_actionExecutor->execute(action,
+                                          {
+                                              .thread = ActionThread::Current,
+                                          });
             }
             break;
         case ExecutionMode::First:
             for (const auto &action : m_actions) {
                 if (evaluateCondition(action)) {
-                    g_actionExecutor->execute(action, {
-                        .thread = ActionThread::Current,
-                    });
+                    g_actionExecutor->execute(action,
+                                              {
+                                                  .thread = ActionThread::Current,
+                                              });
                     break;
                 }
             }

--- a/src/libinputactions/actions/InputAction.cpp
+++ b/src/libinputactions/actions/InputAction.cpp
@@ -81,8 +81,8 @@ bool InputAction::async() const
 bool InputAction::mergeable() const
 {
     return !m_delay.count() && std::ranges::all_of(m_sequence, [](const auto &item) {
-               return !item.mouseAxis.isNull();
-           });
+        return !item.mouseAxis.isNull();
+    });
 }
 
 }

--- a/src/libinputactions/actions/TriggerAction.cpp
+++ b/src/libinputactions/actions/TriggerAction.cpp
@@ -83,9 +83,10 @@ void TriggerAction::triggerCancelled()
 void TriggerAction::tryExecute(uint32_t executions)
 {
     if (canExecute()) {
-        g_actionExecutor->execute(m_action, {
-            .executions = executions,
-        });
+        g_actionExecutor->execute(m_action,
+                                  {
+                                      .executions = executions,
+                                  });
     }
 }
 

--- a/src/libinputactions/handlers/MotionTriggerHandler.h
+++ b/src/libinputactions/handlers/MotionTriggerHandler.h
@@ -69,7 +69,7 @@ protected:
      * Does nothing if there are no active pinch or rotate triggers.
      * @return Whether there are any active pinch or rotate triggers.
      */
-    bool handleMotion(const InputDevice *device, const PointDelta &delta);
+    TEST_VIRTUAL bool handleMotion(const InputDevice *device, const PointDelta &delta);
 
     /**
      * If false is returned, speed is being determined and methods processing triggers must also return true
@@ -99,6 +99,8 @@ private:
     std::vector<TriggerSpeedThreshold> m_speedThresholds;
 
     std::vector<QPointF> m_deltas;
+
+    friend class MockTouchpadTriggerHandler;
 };
 
 }

--- a/src/libinputactions/handlers/TouchpadTriggerHandler.h
+++ b/src/libinputactions/handlers/TouchpadTriggerHandler.h
@@ -68,6 +68,10 @@ private:
     QTimer m_clickTimeoutTimer;
     QTimer m_libinputTapTimeoutTimer;
 
+    bool m_previousPointerAxisEventBlocked{};
+    PointDelta m_pointerAxisDelta;
+
+    friend class MockTouchpadTriggerHandler;
     friend class TestTouchpadTriggerHandler;
 };
 

--- a/src/libinputactions/input/Delta.cpp
+++ b/src/libinputactions/input/Delta.cpp
@@ -33,4 +33,9 @@ qreal PointDelta::unacceleratedHypot() const
     return std::hypot(delta.x(), delta.y());
 }
 
+PointDelta PointDelta::operator+(const PointDelta &other) const
+{
+    return {accelerated() + other.accelerated(), unaccelerated() + other.unaccelerated()};
+}
+
 }

--- a/src/libinputactions/input/Delta.h
+++ b/src/libinputactions/input/Delta.h
@@ -41,6 +41,8 @@ public:
     const T &accelerated() const { return m_accelerated; }
     const T &unaccelerated() const { return m_unaccelerated; };
 
+    bool operator==(const DeltaBase &other) const { return m_accelerated == other.m_accelerated && m_unaccelerated == other.m_unaccelerated; }
+
 private:
     T m_accelerated;
     T m_unaccelerated;
@@ -59,6 +61,8 @@ public:
 
     qreal acceleratedHypot() const;
     qreal unacceleratedHypot() const;
+
+    PointDelta operator+(const PointDelta &other) const;
 };
 
 }

--- a/src/libinputactions/input/backends/LibinputInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibinputInputBackend.cpp
@@ -34,7 +34,7 @@ bool LibinputInputBackend::keyboardKey(InputDevice *sender, uint32_t key, bool s
     return handleEvent(KeyboardKeyEvent(sender, key, state));
 }
 
-bool LibinputInputBackend::pointerAxis(InputDevice *sender, const QPointF &delta)
+bool LibinputInputBackend::pointerAxis(InputDevice *sender, const QPointF &delta, bool oneAxisPerEvent)
 {
     if (m_ignoreEvents || !sender) {
         return false;
@@ -56,7 +56,7 @@ bool LibinputInputBackend::pointerAxis(InputDevice *sender, const QPointF &delta
     if (delta.isNull() && sender->type() == InputDeviceType::Touchpad) {
         LibevdevComplementaryInputBackend::poll(); // Update clicked state, clicking cancels scrolling and generates a (0,0) event
     }
-    return handleEvent(MotionEvent(sender, InputEventType::PointerAxis, {delta}));
+    return handleEvent(MotionEvent(sender, InputEventType::PointerAxis, {delta}, oneAxisPerEvent));
 }
 
 bool LibinputInputBackend::pointerButton(InputDevice *sender, Qt::MouseButton button, uint32_t nativeButton, bool state)

--- a/src/libinputactions/input/backends/LibinputInputBackend.h
+++ b/src/libinputactions/input/backends/LibinputInputBackend.h
@@ -44,7 +44,7 @@ protected:
      * @param sender The event will be ignored if nullptr.
      * @returns Whether to block the event.
      */
-    bool pointerAxis(InputDevice *sender, const QPointF &delta);
+    bool pointerAxis(InputDevice *sender, const QPointF &delta, bool oneAxisPerEvent = false);
     /**
      * Handles mouse and touchpad buttons.
      * @param sender The event will be ignored if nullptr.

--- a/src/libinputactions/input/events.cpp
+++ b/src/libinputactions/input/events.cpp
@@ -37,15 +37,21 @@ InputDevice *InputEvent::sender() const
     return m_sender;
 }
 
-MotionEvent::MotionEvent(InputDevice *sender, InputEventType type, PointDelta delta)
+MotionEvent::MotionEvent(InputDevice *sender, InputEventType type, PointDelta delta, bool oneAxisPerEvent)
     : InputEvent(type, sender)
     , m_delta(std::move(delta))
+    , m_oneAxisPerEvent(oneAxisPerEvent)
 {
 }
 
 const PointDelta &MotionEvent::delta() const
 {
     return m_delta;
+}
+
+bool MotionEvent::oneAxisPerEvent() const
+{
+    return m_oneAxisPerEvent;
 }
 
 PointerButtonEvent::PointerButtonEvent(InputDevice *sender, Qt::MouseButton button, uint32_t nativeButton, bool state)

--- a/src/libinputactions/input/events.h
+++ b/src/libinputactions/input/events.h
@@ -72,12 +72,14 @@ private:
 class MotionEvent : public InputEvent
 {
 public:
-    MotionEvent(InputDevice *sender, InputEventType type, PointDelta delta);
+    MotionEvent(InputDevice *sender, InputEventType type, PointDelta delta, bool oneAxisPerEvent = false);
 
     const PointDelta &delta() const;
+    bool oneAxisPerEvent() const;
 
 private:
     PointDelta m_delta;
+    bool m_oneAxisPerEvent;
 };
 
 class KeyboardKeyEvent : public InputEvent

--- a/tests/libinputactions/actions/TestTriggerAction.cpp
+++ b/tests/libinputactions/actions/TestTriggerAction.cpp
@@ -48,9 +48,12 @@ void TestTriggerAction::triggerUpdated_intervals()
 void TestTriggerAction::triggerUpdated_mergeable()
 {
     uint32_t actualExecutions{};
-    auto action = std::make_unique<TriggerAction>(std::make_shared<CustomAction>([&actualExecutions](auto executions) {
-        actualExecutions = executions;
-    }, false, true));
+    auto action = std::make_unique<TriggerAction>(std::make_shared<CustomAction>(
+        [&actualExecutions](auto executions) {
+            actualExecutions = executions;
+        },
+        false,
+        true));
 
     ActionInterval interval{};
     interval.setValue(1);

--- a/tests/libinputactions/handlers/TestTouchpadTriggerHandler.h
+++ b/tests/libinputactions/handlers/TestTouchpadTriggerHandler.h
@@ -1,6 +1,6 @@
 #include "Test.h"
+#include "mocks/MockTouchpadTriggerHandler.h"
 #include <QSignalSpy>
-#include <libinputactions/handlers/TouchpadTriggerHandler.h>
 
 namespace InputActions
 {
@@ -38,13 +38,22 @@ private slots:
     void tap_fingerCount_data();
     void tap_fingerCount();
 
+    void pointerAxis_oneAxisPerEvent_firstEventPassedThrough();
+    void pointerAxis_oneAxisPerEvent_eventsBlocked();
+    void pointerAxis_oneAxisPerEvent_eventsNotBlocked();
+    void pointerAxis_oneAxisPerEvent_eventBlockingStops();
+    void pointerAxis_oneAxisPerEvent_differentAxisEventsMerged();
+    void pointerAxis_oneAxisPerEvent_sameAxisEventsNotMerged();
+
+    void pointerAxis_notOneAxisPerEvent_notMerged();
+
 private:
     TouchPoint &addPoint(const QPointF &position = {0.5, 0.5});
     void addPoints(uint8_t count, const QPointF &position = {0.5, 0.5});
     void movePoints(const QPointF &delta);
     void removePoints(int16_t count = -1);
 
-    std::unique_ptr<TouchpadTriggerHandler> m_handler;
+    std::unique_ptr<MockTouchpadTriggerHandler> m_handler;
     std::unique_ptr<QSignalSpy> m_activatingTriggerSpy;
     std::unique_ptr<QSignalSpy> m_activatingTriggersSpy;
     std::unique_ptr<QSignalSpy> m_cancellingTriggersSpy;

--- a/tests/libinputactions/mocks/MockTouchpadTriggerHandler.h
+++ b/tests/libinputactions/mocks/MockTouchpadTriggerHandler.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <gmock/gmock.h>
+#include <libinputactions/handlers/TouchpadTriggerHandler.h>
+
+namespace InputActions
+{
+
+class MockTouchpadTriggerHandler : public TouchpadTriggerHandler
+{
+public:
+    MockTouchpadTriggerHandler(InputDevice *device)
+        : TouchpadTriggerHandler(device)
+    {
+        ON_CALL(*this, handleMotion).WillByDefault([this](const auto *device, const auto &delta) {
+            return this->TouchpadTriggerHandler::handleMotion(device, delta);
+        });
+    }
+
+    MOCK_METHOD(bool, handleMotion, (const InputDevice *device, const PointDelta &delta), (override));
+};
+
+}


### PR DESCRIPTION
Hyprland and KWin split libinput touchpad pointer axis events with two axes into two separate events with one axis each, which the circle trigger handler won't like.