### PR TITLE
kwin: override Effect::isActive and Effect::blocksDirectScanout

### DIFF
--- a/src/kwin/Effect.h
+++ b/src/kwin/Effect.h
@@ -34,6 +34,9 @@ public:
     static bool supported() { return true; }
     static bool enabledByDefault() { return false; }
 
+    bool isActive() const override { return false; }
+    bool blocksDirectScanout() const override { return false; }
+
     void reconfigure(ReconfigureFlags flags) override;
 
 protected:


### PR DESCRIPTION
Fixes direct scanout, overlays and possibly some other things being disabled when the KWin plugin is enabled. I'd use a plugin instead of an effect but there is no KCM for plugins, so users would have to use DBus or the debug console to toggle it.