### PR TITLE
ci: restrict opening issues to maintainers

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,103 @@
+# stolen from https://raw.githubusercontent.com/hyprwm/Hyprland/ddae3036ca6a1729ffe7854a59184116d2622809/.github/workflows/close-issues.yml
+name: Close Unauthorized Issues
+
+on:
+  workflow_dispatch:
+  issues:
+    types: [opened]
+
+jobs:
+  close-unauthorized-issues:
+    name: Close Unauthorized Issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # for closing issues
+    steps:
+      # XXX: This *could* be done in Bash by abusing GitHub's own tool to interact with its API
+      # but that's too much of a hack, and we'll be adding a layer of abstraction. github-script
+      # is a workflow that eases interaction with GitHub API in the workflow run context.
+      - name: "Close 'unauthorized' issues"
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const ALLOWED_USERS = ['taj-ny'];
+            const CLOSING_COMMENT = 'Opening issues is restricted to maintainers. Users should use [discussions](https://github.com/taj-ny/InputActions/discussions) instead.';
+
+            async function closeUnauthorizedIssue(issueNumber, userName) {
+              if (ALLOWED_USERS.includes(userName)) {
+                console.log(`Issue #${issueNumber} - Created by authorized user ${userName}`);
+                return;
+              }
+
+              console.log(`Issue #${issueNumber} - Unauthorized, closing`);
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: CLOSING_COMMENT
+              });
+            }
+
+            if (context.eventName === 'issues' && context.payload.action === 'opened') {
+              // Direct access to the issue that triggered the workflow
+              const issue = context.payload.issue;
+
+              // Skip if this is a PR
+              if (issue.pull_request) {
+                console.log(`Issue #${issue.number} - Skipping, this is a pull request`);
+                return;
+              }
+
+              // Process the single issue that triggered the workflow
+              await closeUnauthorizedIssue(issue.number, issue.user.login);
+            } else {
+              // For manual runs, we need to handle pagination
+              async function* fetchAllOpenIssues() {
+                let page = 1;
+                let hasNextPage = true;
+
+                while (hasNextPage) {
+                  const response = await github.rest.issues.listForRepo({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    state: 'open',
+                    per_page: 100,
+                    page: page
+                  });
+
+                  if (response.data.length === 0) {
+                    hasNextPage = false;
+                  } else {
+                    for (const issue of response.data) {
+                      yield issue;
+                    }
+                    page++;
+                  }
+                }
+              }
+
+              // Process issues one by one
+              for await (const issue of fetchAllOpenIssues()) {
+                try {
+                  // Skip pull requests
+                  if (issue.pull_request) {
+                    console.log(`Issue #${issue.number} - Skipping, this is a pull request`);
+                    continue;
+                  }
+
+                  await closeUnauthorizedIssue(issue.number, issue.user.login);
+                } catch (error) {
+                  console.error(`Error processing issue #${issue.number}: ${error.message}`);
+                }
+              }
+            }


### PR DESCRIPTION
Because people make a mess out of it with questions. [Discussions](https://github.com/taj-ny/InputActions/discussions) should be used from now on.