### PR TITLE
core: add per-action multiplier for move_by_delta actions

### DIFF
--- a/src/libinputactions/actions/InputAction.cpp
+++ b/src/libinputactions/actions/InputAction.cpp
@@ -62,7 +62,7 @@ void InputAction::executeImpl(uint32_t executions)
             } else if (!item.mouseMoveRelative.isNull()) {
                 g_inputBackend->virtualMouse()->mouseMotion(item.mouseMoveRelative);
             } else if (item.mouseMoveRelativeByDelta) {
-                g_inputBackend->virtualMouse()->mouseMotion(m_deltaMultiplied);
+                g_inputBackend->virtualMouse()->mouseMotion(m_deltaMultiplied * item.mouseMoveRelativeByDelta);
             }
         });
 

--- a/src/libinputactions/actions/InputAction.h
+++ b/src/libinputactions/actions/InputAction.h
@@ -44,7 +44,12 @@ public:
         QPointF mouseAxis;
         QPointF mouseMoveAbsolute;
         QPointF mouseMoveRelative;
-        bool mouseMoveRelativeByDelta{};
+
+        /**
+         * 0 - unset
+         * Any other value - delta multiplier
+         */
+        qreal mouseMoveRelativeByDelta{};
     };
 
     InputAction(std::vector<Item> sequence);

--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -1374,8 +1374,17 @@ struct convert<std::vector<InputAction::Item>>
                             });
                         }
                     } else if (action.startsWith("MOVE_BY_DELTA")) {
+                        qreal multiplier = 1;
+                        if (arguments.size() > 0) {
+                            bool ok{};
+                            multiplier = arguments.at(0).toDouble(&ok);
+                            if (!ok) {
+                                throw Exception(node.Mark(), "move_by_delta multiplier is not a number");
+                            }
+                        }
+
                         value.push_back({
-                            .mouseMoveRelativeByDelta = true,
+                            .mouseMoveRelativeByDelta = multiplier,
                         });
                     } else if (action.startsWith("MOVE_BY")) {
                         value.push_back({

--- a/src/libinputactions/handlers/MotionTriggerHandler.h
+++ b/src/libinputactions/handlers/MotionTriggerHandler.h
@@ -54,7 +54,7 @@ public:
     void setSpeedThreshold(TriggerType type, qreal threshold, TriggerDirection directions = UINT32_MAX);
 
     /**
-     * Used for the move_by_delta mouse input action. Temporary workaround.
+     * Global move_by_delta delta multiplier. Deprecated, use InputAction::Item::mouseMoveRelativeByDelta instead.
      */
     void setSwipeDeltaMultiplier(qreal value) { m_swipeDeltaMultiplier = value; }
 


### PR DESCRIPTION
```yaml
input:
  - mouse: [ move_by_delta 0.5 ] # multiply by 0.5
  - mouse: [ move_by_delta ] # multiply by 1 (default)
```

Stacks with ``touchpad.delta_multiplier``, which is now deprecated.