### PR TITLE
core: move TriggerHandler settings to device properties

### DIFF
--- a/src/hyprland/input/HyprlandInputDevice.cpp
+++ b/src/hyprland/input/HyprlandInputDevice.cpp
@@ -33,7 +33,7 @@ HyprlandInputDevice::HyprlandInputDevice(SP<IHID> device, InputDeviceType type, 
     , m_backend(backend)
 {
     if (g_pConfigManager->getDeviceString(name, "tap_button_map", "input:touchpad:tap_button_map") == "lmr") {
-        properties().setLmrTapButtonMap(true);
+        properties().setTouchpadLmrTapButtonMap(true);
     }
 }
 

--- a/src/kwin/input/KWinInputDevice.cpp
+++ b/src/kwin/input/KWinInputDevice.cpp
@@ -30,7 +30,7 @@ KWinInputDevice::KWinInputDevice(KWinInputBackend *backend, KWin::InputDevice *d
     , m_backend(backend)
 {
     if (device->property("lmrTapButtonMap").value<bool>()) {
-        properties().setLmrTapButtonMap(true);
+        properties().setTouchpadLmrTapButtonMap(true);
     }
     if (type == InputDeviceType::Touchscreen) {
         properties().setSize(device->property("size").value<QSizeF>());

--- a/src/libinputactions/handlers/MouseTriggerHandler.h
+++ b/src/libinputactions/handlers/MouseTriggerHandler.h
@@ -41,21 +41,6 @@ class MouseTriggerHandler : public MotionTriggerHandler
 public:
     MouseTriggerHandler();
 
-    /**
-     * The amount of time in the handler will wait for motion to be performed (wheel is considered motion as well) before attempting to activate press triggers.
-     * For pointer motion there is a small threshold to prevent accidental activations.
-     */
-    void setMotionTimeout(std::chrono::milliseconds value) { m_motionTimeout = std::move(value); }
-    /**
-     * The amount of time the handler will wait for all mouse buttons to be pressed before activating press triggers.
-     */
-    void setPressTimeout(std::chrono::milliseconds value) { m_pressTimeout = std::move(value); }
-
-    /**
-     * Whether blocked mouse buttons should be pressed immediately on timeout. If false, they will be pressed and instantly released on button release.
-     */
-    void setUnblockButtonsOnTimeout(bool value) { m_unblockButtonsOnTimeout = value; }
-
 protected:
     bool keyboardKey(const KeyboardKeyEvent &event) override;
 
@@ -105,10 +90,6 @@ private:
 
     QList<uint32_t> m_blockedMouseButtons;
     std::vector<Qt::MouseButton> m_buttons;
-
-    std::chrono::milliseconds m_motionTimeout{200L};
-    std::chrono::milliseconds m_pressTimeout{50L};
-    bool m_unblockButtonsOnTimeout = true;
 };
 
 }

--- a/src/libinputactions/handlers/TouchpadTriggerHandler.cpp
+++ b/src/libinputactions/handlers/TouchpadTriggerHandler.cpp
@@ -108,9 +108,9 @@ bool TouchpadTriggerHandler::pointerButton(const PointerButtonEvent &event)
                 if (event.nativeButton() == BTN_LEFT) {
                     fingers = 1;
                 } else if (event.nativeButton() == BTN_RIGHT) {
-                    fingers = event.sender()->properties().lmrTapButtonMap() ? 3 : 2;
+                    fingers = event.sender()->properties().touchpadLmrTapButtonMap() ? 3 : 2;
                 } else if (event.nativeButton() == BTN_MIDDLE) {
-                    fingers = event.sender()->properties().lmrTapButtonMap() ? 2 : 3;
+                    fingers = event.sender()->properties().touchpadLmrTapButtonMap() ? 2 : 3;
                 } else {
                     break;
                 }
@@ -267,7 +267,7 @@ bool TouchpadTriggerHandler::touchpadGestureLifecyclePhase(const TouchpadGesture
                     }
                     activateTriggers(triggers);
                 });
-                m_clickTimeoutTimer.start(std::max(TAP_TIMEOUT.count(), m_clickTimeout.count()));
+                m_clickTimeoutTimer.start(std::max(TAP_TIMEOUT.count(), m_device->properties().touchpadClickTimeout().count()));
                 return m_gestureBeginBlocked;
             }
 

--- a/src/libinputactions/handlers/TouchpadTriggerHandler.h
+++ b/src/libinputactions/handlers/TouchpadTriggerHandler.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <libinputactions/handlers/MultiTouchMotionTriggerHandler.h>
 #include <libinputactions/input/devices/InputDeviceState.h>
 
@@ -34,12 +33,6 @@ class TouchpadTriggerHandler : public MultiTouchMotionTriggerHandler
 {
 public:
     TouchpadTriggerHandler(InputDevice *device);
-
-    /**
-     * The time for the user to perform a click once a press gesture had been detected by libinput. If the click is not performed, the press trigger is
-     * activated.
-     */
-    void setClickTimeout(std::chrono::milliseconds value) { m_clickTimeout = value; }
 
 protected:
     /**
@@ -75,8 +68,6 @@ private:
 
     bool m_previousPointerAxisEventBlocked{};
     PointDelta m_pointerAxisDelta;
-
-    std::chrono::milliseconds m_clickTimeout{200L};
 
     TouchPoint m_firstTouchPoint;
 

--- a/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
+++ b/src/libinputactions/input/backends/LibevdevComplementaryInputBackend.cpp
@@ -100,7 +100,7 @@ void LibevdevComplementaryInputBackend::addDevice(InputDevice *device, std::shar
     auto &properties = device->properties();
     properties.setSize({data->virtualSize.width() / static_cast<qreal>(x->resolution), data->virtualSize.height() / static_cast<qreal>(y->resolution)});
     properties.setMultiTouch(multiTouch);
-    properties.setButtonPad(buttonPad);
+    properties.setTouchpadButtonPad(buttonPad);
 
     if (owner) {
         connect(data->device.get(), &libevdev::Device::eventsAvailable, this, [this, device] {
@@ -161,7 +161,7 @@ void LibevdevComplementaryInputBackend::handleEvdevEvent(InputDevice *sender, co
                 case BTN_LEFT:
                 case BTN_MIDDLE:
                 case BTN_RIGHT:
-                    if (properties.buttonPad()) {
+                    if (properties.touchpadButtonPad()) {
                         handleEvent(TouchpadClickEvent(sender, value));
                     }
                     break;

--- a/src/libinputactions/input/devices/InputDeviceProperties.cpp
+++ b/src/libinputactions/input/devices/InputDeviceProperties.cpp
@@ -37,11 +37,15 @@ void InputDeviceProperties::apply(const InputDeviceProperties &other)
     apply(m_handleLibevdevEvents, other.m_handleLibevdevEvents);
     apply(m_multiTouch, other.m_multiTouch);
     apply(m_size, other.m_size);
-    apply(m_buttonPad, other.m_buttonPad);
     apply(m_fingerPressure, other.m_fingerPressure);
     apply(m_thumbPressure, other.m_thumbPressure);
     apply(m_palmPressure, other.m_palmPressure);
-    apply(m_lmrTapButtonMap, other.m_lmrTapButtonMap);
+    apply(m_mouseMotionTimeout, other.m_mouseMotionTimeout);
+    apply(m_mousePressTimeout, other.m_mousePressTimeout);
+    apply(m_mouseUnblockButtonsOnTimeout, other.m_mouseUnblockButtonsOnTimeout);
+    apply(m_touchpadButtonPad, other.m_touchpadButtonPad);
+    apply(m_touchpadClickTimeout, other.m_touchpadClickTimeout);
+    apply(m_touchpadLmrTapButtonMap, other.m_touchpadLmrTapButtonMap);
 }
 
 QString InputDeviceProperties::toString() const
@@ -81,11 +85,6 @@ QSizeF InputDeviceProperties::size() const
     return m_size.value_or(QSizeF());
 }
 
-bool InputDeviceProperties::buttonPad() const
-{
-    return m_buttonPad.value_or(false);
-}
-
 uint32_t InputDeviceProperties::fingerPressure() const
 {
     return m_fingerPressure.value_or(0);
@@ -101,9 +100,34 @@ uint32_t InputDeviceProperties::palmPressure() const
     return m_palmPressure.value_or(UINT32_MAX);
 }
 
-bool InputDeviceProperties::lmrTapButtonMap() const
+std::chrono::milliseconds InputDeviceProperties::mouseMotionTimeout() const
 {
-    return m_lmrTapButtonMap.value_or(false);
+    return m_mouseMotionTimeout.value_or(std::chrono::milliseconds{200L});
+}
+
+std::chrono::milliseconds InputDeviceProperties::mousePressTimeout() const
+{
+    return m_mousePressTimeout.value_or(std::chrono::milliseconds{50L});
+}
+
+bool InputDeviceProperties::mouseUnblockButtonsOnTimeout() const
+{
+    return m_mouseUnblockButtonsOnTimeout.value_or(true);
+}
+
+bool InputDeviceProperties::touchpadButtonPad() const
+{
+    return m_touchpadButtonPad.value_or(false);
+}
+
+std::chrono::milliseconds InputDeviceProperties::touchpadClickTimeout() const
+{
+    return m_touchpadClickTimeout.value_or(std::chrono::milliseconds{200L});
+}
+
+bool InputDeviceProperties::touchpadLmrTapButtonMap() const
+{
+    return m_touchpadLmrTapButtonMap.value_or(false);
 }
 
 }

--- a/src/libinputactions/input/devices/InputDeviceProperties.h
+++ b/src/libinputactions/input/devices/InputDeviceProperties.h
@@ -20,6 +20,7 @@
 
 #include <QMetaObject>
 #include <QSizeF>
+#include <chrono>
 #include <optional>
 
 namespace InputActions
@@ -29,16 +30,22 @@ class InputDeviceProperties
 {
     Q_GADGET
 
-    Q_PROPERTY(bool buttonPad READ buttonPad)
     Q_PROPERTY(uint32_t fingerPressure READ fingerPressure)
     Q_PROPERTY(bool grab READ grab)
     Q_PROPERTY(bool handleLibevdevEvents READ handleLibevdevEvents)
     Q_PROPERTY(bool ignore READ ignore)
-    Q_PROPERTY(bool lmrTapButtonMap READ lmrTapButtonMap)
     Q_PROPERTY(bool multiTouch READ multiTouch)
     Q_PROPERTY(uint32_t palmPressure READ palmPressure)
     Q_PROPERTY(QSizeF size READ size)
     Q_PROPERTY(uint32_t thumbPressure READ thumbPressure)
+
+    Q_PROPERTY(std::chrono::milliseconds mouseMotionTimeout READ mouseMotionTimeout)
+    Q_PROPERTY(std::chrono::milliseconds mousePressTimeout READ mousePressTimeout)
+    Q_PROPERTY(bool mouseUnblockButtonsOnTimeout READ mouseUnblockButtonsOnTimeout)
+
+    Q_PROPERTY(bool touchpadButtonPad READ touchpadButtonPad)
+    Q_PROPERTY(std::chrono::milliseconds touchpadClickTimeout READ touchpadClickTimeout)
+    Q_PROPERTY(bool touchpadLmrTapButtonMap READ touchpadLmrTapButtonMap)
 
 public:
     InputDeviceProperties() = default;
@@ -79,13 +86,6 @@ public:
      * @internal
      */
     void setSize(const QSizeF &value) { m_size = value; }
-
-    /**
-     * Whether INPUT_PROP_BUTTONPAD is present.
-     */
-    bool buttonPad() const;
-    void setButtonPad(bool value) { m_buttonPad = value; }
-
     /**
      * Minimum pressure for a touch point to be considered a finger.
      */
@@ -105,10 +105,42 @@ public:
     void setPalmPressure(uint32_t value) { m_palmPressure = value; }
 
     /**
+     * The amount of time in the handler will wait for motion to be performed (wheel is considered motion as well) before attempting to activate press triggers.
+     * For pointer motion there is a small threshold to prevent accidental activations.
+     */
+    std::chrono::milliseconds mouseMotionTimeout() const;
+    void setMouseMotionTimeout(std::chrono::milliseconds value) { m_mouseMotionTimeout = value; }
+
+    /**
+     * The amount of time the handler will wait for all mouse buttons to be pressed before activating press triggers.
+     */
+    std::chrono::milliseconds mousePressTimeout() const;
+    void setMousePressTimeout(std::chrono::milliseconds value) { m_mousePressTimeout = value; }
+
+    /**
+     * Whether blocked mouse buttons should be pressed immediately on timeout. If false, they will be pressed and instantly released on button release.
+     */
+    bool mouseUnblockButtonsOnTimeout() const;
+    void setMouseUnblockButtonsOnTimeout(bool value) { m_mouseUnblockButtonsOnTimeout = value; }
+
+    /**
+     * Whether INPUT_PROP_BUTTONPAD is present.
+     */
+    bool touchpadButtonPad() const;
+    void setTouchpadButtonPad(bool value) { m_touchpadButtonPad = value; }
+
+    /**
+     * The time for the user to perform a click once a press gesture had been detected by libinput. If the click is not performed, the press trigger is
+     * activated.
+     */
+    std::chrono::milliseconds touchpadClickTimeout() const;
+    void setTouchpadClickTimeout(std::chrono::milliseconds value) { m_touchpadClickTimeout = value; }
+
+    /**
      * Whether tapping is mapped to left (1 finger), middle (2) and right (3) buttons.
      */
-    bool lmrTapButtonMap() const;
-    void setLmrTapButtonMap(bool value) { m_lmrTapButtonMap = value; }
+    bool touchpadLmrTapButtonMap() const;
+    void setTouchpadLmrTapButtonMap(bool value) { m_touchpadLmrTapButtonMap = value; }
 
     QString toString() const;
 
@@ -120,12 +152,17 @@ private:
     std::optional<bool> m_multiTouch;
     std::optional<QSizeF> m_size;
 
-    std::optional<bool> m_buttonPad;
     std::optional<uint32_t> m_fingerPressure;
     std::optional<uint32_t> m_thumbPressure;
     std::optional<uint32_t> m_palmPressure;
 
-    std::optional<bool> m_lmrTapButtonMap;
+    std::optional<std::chrono::milliseconds> m_mouseMotionTimeout;
+    std::optional<std::chrono::milliseconds> m_mousePressTimeout;
+    std::optional<bool> m_mouseUnblockButtonsOnTimeout;
+
+    std::optional<bool> m_touchpadButtonPad;
+    std::optional<std::chrono::milliseconds> m_touchpadClickTimeout;
+    std::optional<bool> m_touchpadLmrTapButtonMap;
 };
 
 }

--- a/src/libinputactions/utils/QVariantUtils.cpp
+++ b/src/libinputactions/utils/QVariantUtils.cpp
@@ -23,12 +23,20 @@
 namespace InputActions
 {
 
-QString QVariantUtils::toString(QVariant variant)
+QString QVariantUtils::toString(const QVariant &variant)
 {
-    switch (variant.userType()) {
-        case QMetaType::QSizeF:
+    const auto userType = variant.userType();
+    switch (userType) {
+        case QMetaType::QSizeF: {
             const auto value = variant.toSizeF();
             return QString("%1,%2").arg(QString::number(value.width()), QString::number(value.height()));
+        }
+        default:
+            if (userType == qMetaTypeId<std::chrono::milliseconds>()) {
+                const auto value = variant.value<std::chrono::milliseconds>();
+                return QString("%1 ms").arg(QString::number(value.count()));
+            }
+            break;
     }
 
     return variant.toString();

--- a/src/libinputactions/utils/QVariantUtils.h
+++ b/src/libinputactions/utils/QVariantUtils.h
@@ -26,7 +26,7 @@ namespace InputActions
 class QVariantUtils
 {
 public:
-    static QString toString(QVariant variant);
+    static QString toString(const QVariant &variant);
 };
 
 }

--- a/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
+++ b/tests/libinputactions/handlers/TestTouchpadTriggerHandler.cpp
@@ -399,7 +399,7 @@ void TestTouchpadTriggerHandler::tap_fingerCount()
     auto trigger = std::make_unique<Trigger>(TriggerType::Tap);
     trigger->setActivationCondition(std::make_shared<VariableCondition>("fingers", InputActions::Value<qreal>(triggerFingers), ComparisonOperator::EqualTo));
     m_handler->addTrigger(std::move(trigger));
-    m_touchpad->properties().setLmrTapButtonMap(lmrTapButtonMap);
+    m_touchpad->properties().setTouchpadLmrTapButtonMap(lmrTapButtonMap);
 
     addPoints(fingers);
     removePoints();


### PR DESCRIPTION
The following properties may now be configured on a per-device basis with device rules:
- mouse: ``motion_timeout``, ``press_timeout``, ``unblock_buttons_on_timeout``
- touchpad: ``click_timeout``

```yaml
device_rules:
  - conditions: $types contains mouse
    press_timeout: 300
    unblock_buttons_on_timeout: false

  - conditions: $types contains touchpad
    click_timeout: 300
```

The previous method of setting those properties is now deprecated.