### PR TITLE
core: add option to disable external variable access

### DIFF
--- a/src/libinputactions/config/ConfigLoader.cpp
+++ b/src/libinputactions/config/ConfigLoader.cpp
@@ -42,6 +42,7 @@ const static QString CRASH_PREVENTION_FILE = QStandardPaths::writableLocation(QS
 
 struct Config
 {
+    bool allowExternalVariableAccess = true;
     bool autoReload = true;
     bool libevdevEnabled = true;
     bool sendNotificationOnError = true;
@@ -96,6 +97,7 @@ Config ConfigLoader::createConfig(const QString &raw)
 
     Config config;
     YAML::loadMember(config.autoReload, root["autoreload"]);
+    YAML::loadMember(config.allowExternalVariableAccess, root["external_variable_access"]);
     if (const auto &notificationsNode = root["notifications"]) {
         YAML::loadMember(config.sendNotificationOnError, notificationsNode["config_error"]);
     }
@@ -128,6 +130,7 @@ void ConfigLoader::activateConfig(Config config, bool initialize)
     g_actionExecutor->clearQueue();
     g_actionExecutor->waitForDone();
 
+    g_globalConfig->setAllowExternalVariableAccess(config.allowExternalVariableAccess);
     g_globalConfig->setAutoReload(config.autoReload);
     g_globalConfig->setSendNotificationOnError(config.sendNotificationOnError);
 

--- a/src/libinputactions/config/GlobalConfig.h
+++ b/src/libinputactions/config/GlobalConfig.h
@@ -27,14 +27,20 @@ namespace InputActions
 class GlobalConfig
 {
 public:
+    /**
+     * Allow external programs to read InputActions variables.
+     */
+    bool allowExternalVariableAccess() const { return m_allowExternalVariableAccess; }
+    void setAllowExternalVariableAccess(bool value) { m_allowExternalVariableAccess = value; }
+
     bool autoReload() const { return m_autoReload; }
     void setAutoReload(bool value) { m_autoReload = value; }
 
     bool sendNotificationOnError() const { return m_sendNotificationOnError; }
     void setSendNotificationOnError(bool value) { m_sendNotificationOnError = value; }
-
 private:
     // Default values defined in Config
+    bool m_allowExternalVariableAccess{};
     bool m_autoReload{};
     bool m_sendNotificationOnError{};
 };

--- a/src/libinputactions/dbus/DBusInterfaceBase.cpp
+++ b/src/libinputactions/dbus/DBusInterfaceBase.cpp
@@ -18,6 +18,7 @@
 
 #include "DBusInterfaceBase.h"
 #include <QRegularExpression>
+#include <libinputactions/config/GlobalConfig.h>
 #include <libinputactions/input/backends/InputBackend.h>
 #include <libinputactions/input/devices/InputDevice.h>
 #include <libinputactions/triggers/StrokeTrigger.h>
@@ -53,6 +54,10 @@ QString DBusInterfaceBase::strokeToBase64(const Stroke &stroke)
 
 QString DBusInterfaceBase::variableList(const VariableManager *variableManager, const QString &filter)
 {
+    if (!g_globalConfig->allowExternalVariableAccess()) {
+        return "External variable access has been disabled. Set 'external_variable_access' to 'true' to enable.";
+    }
+
     QStringList result;
     const QRegularExpression filterRegex(filter);
     for (const auto &[name, variable] : variableManager->variables()) {


### PR DESCRIPTION
New root property:
| Property | Type | Description | Default |
|-|-|-|-|
| external_variable_access | *bool* | Allow dumping variables by running ``inputactions variables list``. | ``true`` |

closes #243 