### PR TITLE
core: add non-conflicting actions

### DIFF
--- a/src/libinputactions/actions/TriggerAction.h
+++ b/src/libinputactions/actions/TriggerAction.h
@@ -166,6 +166,12 @@ public:
     const std::optional<Range<qreal>> &threshold() const { return m_threshold; }
     void setThreshold(Range<qreal> value) { m_threshold = std::move(value); }
 
+    /**
+     * Whether this action can activate conflict resolution.
+     */
+    bool conflicting() const { return m_conflicting; }
+    void setConflicting(bool value) { m_conflicting = value; }
+
 private:
     void update(const Delta &delta);
 
@@ -179,6 +185,7 @@ private:
     ActionInterval m_interval;
     On m_on = On::End;
     std::optional<Range<qreal>> m_threshold;
+    bool m_conflicting = true;
 
     /**
      * The sum of deltas from update events. Reset when the direction changes.

--- a/src/libinputactions/config/yaml.h
+++ b/src/libinputactions/config/yaml.h
@@ -1023,6 +1023,7 @@ struct convert<std::unique_ptr<TriggerAction>>
     {
         value = std::make_unique<TriggerAction>(node.as<std::shared_ptr<Action>>());
 
+        loadSetter(value, &TriggerAction::setConflicting, node["conflicting"]);
         loadSetter(value, &TriggerAction::setInterval, node["interval"]);
         loadSetter(value, &TriggerAction::setOn, node["on"]);
         loadSetter(value, &TriggerAction::setThreshold, node["threshold"]);

--- a/src/libinputactions/triggers/Trigger.cpp
+++ b/src/libinputactions/triggers/Trigger.cpp
@@ -152,7 +152,7 @@ bool Trigger::overridesOtherTriggersOnEnd()
     }
 
     return std::ranges::any_of(m_actions, [](const auto &action) {
-        return (action->on() == On::End || action->on() == On::EndCancel) && action->canExecute();
+        return action->conflicting() && (action->on() == On::End || action->on() == On::EndCancel) && action->canExecute();
     });
 }
 
@@ -163,7 +163,7 @@ bool Trigger::overridesOtherTriggersOnUpdate()
     }
 
     return std::ranges::any_of(m_actions, [](const auto &action) {
-        return action->action()->executions() || (action->on() == On::Update && action->canExecute());
+        return action->conflicting() && (action->action()->executions() || (action->on() == On::Update && action->canExecute()));
     });
 }
 


### PR DESCRIPTION
New action property:
| Property | Type | Description | Default |
|-|-|-|-|
| conflicting | *bool* | Whether this action can activate trigger conflict resolution. | ``true`` |