### PR TITLE
core: make the emergency combination configurable

### DIFF
--- a/src/libinputactions/config/ConfigLoader.cpp
+++ b/src/libinputactions/config/ConfigLoader.cpp
@@ -54,6 +54,7 @@ struct Config
     std::function<std::unique_ptr<TouchscreenTriggerHandler>(InputDevice *device)> touchscreenTriggerHandlerFactory;
 
     std::vector<InputDeviceRule> deviceRules;
+    std::set<KeyboardKey> emergencyCombination = {KEY_BACKSPACE, KEY_SPACE, KEY_ENTER};
 };
 
 void ConfigLoader::loadEmpty()
@@ -103,6 +104,7 @@ Config ConfigLoader::createConfig(const QString &raw)
     }
     YAML::loadMember(config.libevdevEnabled, root["__libevdev_enabled"]);
     YAML::loadMember(config.deviceRules, root);
+    YAML::loadMember(config.emergencyCombination, root["emergency_combination"]);
 
     YAML::loadMember(config.keyboardTriggerHandler, root["keyboard"]);
     YAML::loadMember(config.mouseTriggerHandler, root["mouse"]);
@@ -144,6 +146,7 @@ void ConfigLoader::activateConfig(Config config, bool initialize)
     g_inputBackend->setTouchpadTriggerHandlerFactory(config.touchpadTriggerHandlerFactory);
     g_inputBackend->setTouchscreenTriggerHandlerFactory(config.touchscreenTriggerHandlerFactory);
     g_inputBackend->setDeviceRules(config.deviceRules);
+    g_inputBackend->setEmergencyCombination(config.emergencyCombination);
 
     if (initialize) {
         g_inputBackend->initialize();

--- a/src/libinputactions/input/backends/InputBackend.h
+++ b/src/libinputactions/input/backends/InputBackend.h
@@ -177,7 +177,7 @@ private:
     std::function<std::unique_ptr<TouchpadTriggerHandler>(InputDevice *device)> m_touchpadTriggerHandlerFactory;
     std::function<std::unique_ptr<TouchscreenTriggerHandler>(InputDevice *device)> m_touchscreenTriggerHandlerFactory;
 
-    std::set<KeyboardKey> m_emergencyCombination = {KEY_BACKSPACE, KEY_SPACE, KEY_ENTER};
+    std::set<KeyboardKey> m_emergencyCombination; // Default value defined in Config
 };
 
 inline std::unique_ptr<InputBackend> g_inputBackend;


### PR DESCRIPTION
New root property:
| Property | Type | Description | Default |
|-|-|-|-|
| emergency_combination | *list(keyboard_key)* | Keyboard keys that can be pressed in any order and held for 2 seconds to suspend InputActions until the next config reload.<br>Set to an empty list to disable. | ``[ backspace, enter, space ]`` |