### PR TITLE
client/wayland: fix crash on wl_output removal (e.g. lid close)

### DIFF
--- a/src/standalone/client/wayland/WaylandProtocolManager.cpp
+++ b/src/standalone/client/wayland/WaylandProtocolManager.cpp
@@ -24,7 +24,10 @@ namespace InputActions
 
 WaylandProtocolManager::WaylandProtocolManager(wl_registry *registry)
 {
-    static const wl_registry_listener listener(&WaylandProtocolManager::handleGlobal);
+    static const wl_registry_listener listener{
+        .global = &WaylandProtocolManager::handleGlobal,
+        .global_remove = INPUTACTIONS_NOOP_3,
+    };
     wl_registry_add_listener(registry, &listener, this);
 }
 

--- a/src/standalone/client/wayland/WlrForeignToplevelManagementV1.cpp
+++ b/src/standalone/client/wayland/WlrForeignToplevelManagementV1.cpp
@@ -44,7 +44,10 @@ void WlrForeignToplevelManagementV1::bind(wl_registry *registry, uint32_t name, 
 {
     WaylandProtocol::bind(registry, name, version);
 
-    static const zwlr_foreign_toplevel_manager_v1_listener listener(&WlrForeignToplevelManagementV1::handleToplevel);
+    static const zwlr_foreign_toplevel_manager_v1_listener listener{
+        .toplevel = &WlrForeignToplevelManagementV1::handleToplevel,
+        .finished = INPUTACTIONS_NOOP_2,
+    };
 
     m_manager = static_cast<zwlr_foreign_toplevel_manager_v1 *>(wl_registry_bind(registry, name, &zwlr_foreign_toplevel_manager_v1_interface, version));
     zwlr_foreign_toplevel_manager_v1_add_listener(m_manager, &listener, this);


### PR DESCRIPTION
Wayland listeners constructed with a single function pointer left remaining handler slots null. libwayland aborts when it dispatches an event through a null function pointer.

Provide no-op handlers for wl_registry::global_remove and zwlr_foreign_toplevel_manager_v1::finished to prevent the crash.