### PR TITLE
standalone/client: add missing event handlers; fix memory leaks

### DIFF
--- a/src/standalone/client/wayland/WaylandProtocol.cpp
+++ b/src/standalone/client/wayland/WaylandProtocol.cpp
@@ -19,27 +19,27 @@
 #include "WaylandProtocol.h"
 #include <QLoggingCategory>
 
+Q_LOGGING_CATEGORY(INPUTACTIONS_WAYLAND, "inputactions.wayland", QtWarningMsg);
+
 namespace InputActions
 {
 
-WaylandProtocol::WaylandProtocol(QString name)
-    : m_name(std::move(name))
+WaylandProtocol::WaylandProtocol(QString interface)
+    : m_interface(std::move(interface))
 {
 }
 
 void WaylandProtocol::bind(wl_registry *registry, uint32_t name, uint32_t version)
 {
+    qCDebug(INPUTACTIONS_WAYLAND).noquote() << QString("Bound protocol %1").arg(m_interface);
+
+    m_name = name;
     m_supported = true;
 }
 
-const QString &WaylandProtocol::name() const
+void WaylandProtocol::destroy()
 {
-    return m_name;
-}
-
-bool WaylandProtocol::supported() const
-{
-    return m_supported;
+    qCDebug(INPUTACTIONS_WAYLAND).noquote() << QString("Destroyed protocol %1").arg(m_interface);
 }
 
 }

--- a/src/standalone/client/wayland/WaylandProtocol.h
+++ b/src/standalone/client/wayland/WaylandProtocol.h
@@ -33,15 +33,21 @@ public:
     virtual ~WaylandProtocol() = default;
 
     virtual void bind(wl_registry *registry, uint32_t name, uint32_t version);
+    /**
+     * The protocol may be bound again after being destroyed.
+     */
+    virtual void destroy();
 
-    const QString &name() const;
-    bool supported() const;
+    uint32_t name() const { return m_name; }
+    const QString &interface() const { return m_interface; }
+    bool supported() const { return m_supported; }
 
 protected:
-    WaylandProtocol(QString name);
+    WaylandProtocol(QString interface);
 
 private:
-    QString m_name;
+    uint32_t m_name{};
+    QString m_interface;
     bool m_supported{};
 };
 

--- a/src/standalone/client/wayland/WaylandProtocolManager.h
+++ b/src/standalone/client/wayland/WaylandProtocolManager.h
@@ -37,6 +37,7 @@ public:
 
 private:
     static void handleGlobal(void *data, wl_registry *registry, uint32_t name, const char *interface, uint32_t version);
+    static void handleGlobalRemove(void *data, wl_registry *registry, uint32_t name);
 
     std::vector<std::unique_ptr<WaylandProtocol>> m_protocols;
 };

--- a/src/standalone/client/wayland/WlrForeignToplevelManagementV1.h
+++ b/src/standalone/client/wayland/WlrForeignToplevelManagementV1.h
@@ -42,9 +42,11 @@ public:
 
 protected:
     void bind(wl_registry *registry, uint32_t name, uint32_t version) override;
+    void destroy() final;
 
 private:
     static void handleToplevel(void *data, zwlr_foreign_toplevel_manager_v1 *manager, zwlr_foreign_toplevel_handle_v1 *toplevel);
+    static void handleFinished(void *data, zwlr_foreign_toplevel_manager_v1 *manager);
 
     static void handleTitle(void *data, zwlr_foreign_toplevel_handle_v1 *handle, const char *title);
     static void handleAppId(void *data, zwlr_foreign_toplevel_handle_v1 *handle, const char *appId);


### PR DESCRIPTION
fixes #415 and some memory leaks when global objects are destroyed