### PR TITLE
standalone/client: don't initialize wayland client on gnome

### DIFF
--- a/src/standalone/client/gnome/GNOMEClient.cpp
+++ b/src/standalone/client/gnome/GNOMEClient.cpp
@@ -25,11 +25,6 @@ namespace InputActions
 static const QDir GNOME_EXTENSIONS_DIR = QDir::homePath() + "/.local/share/gnome-shell/extensions";
 static const QDir GNOME_EXTENSION_DIR = GNOME_EXTENSIONS_DIR.path() + "/inputactions@inputactions.org";
 
-GNOMEClient::GNOMEClient(Client *client)
-    : WaylandClient(client)
-{
-}
-
 bool GNOMEClient::initialize()
 {
     if (!qEnvironmentVariable("XDG_CURRENT_DESKTOP").toLower().contains("gnome")) {
@@ -37,7 +32,7 @@ bool GNOMEClient::initialize()
     }
 
     installFiles();
-    return WaylandClient::initialize();
+    return true;
 }
 
 void GNOMEClient::installFiles()

--- a/src/standalone/client/gnome/GNOMEClient.h
+++ b/src/standalone/client/gnome/GNOMEClient.h
@@ -18,16 +18,12 @@
 
 #pragma once
 
-#include "client/wayland/WaylandClient.h"
-
 namespace InputActions
 {
 
-class GNOMEClient : public WaylandClient
+class GNOMEClient
 {
 public:
-    GNOMEClient(Client *client);
-
     /**
      * @returns Whether the GNOME client was successfully initialized.
      */

--- a/src/standalone/client/main.cpp
+++ b/src/standalone/client/main.cpp
@@ -53,7 +53,7 @@ int main()
 
     ClientMessageHandler messageHandler(client);
 
-    GNOMEClient gnomeClient(client);
+    GNOMEClient gnomeClient;
     PlasmaClient plasmaClient;
     WaylandClient waylandClient(client);
     gnomeClient.initialize() || plasmaClient.initialize() || waylandClient.initialize();


### PR DESCRIPTION
GNOME doesn't even implement zwlr_foreign_toplevel_manager_v1 so it's useless, and even it if did, the Wayland client would conflict with the GNOME client.